### PR TITLE
Fix Warning: Setting linear velocity of a kinematic body is not supported.

### DIFF
--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody.cs
@@ -92,6 +92,9 @@ namespace PurrNet.Prediction
 
         public override void OnPreSetup()
         {
+            if (_rigidbody.isKinematic)
+                return;
+
             linearVelocity = default;
             angularVelocity = default;
         }


### PR DESCRIPTION
Checks if the rigidbody is Kinematic before trying to set velocity and angularVelocity to prevent warnings
<img width="469" height="154" alt="image" src="https://github.com/user-attachments/assets/c510f2f5-e50e-4ce8-9e09-57ff7a2e2a25" />

```
Setting linear velocity of a kinematic body is not supported.
UnityEngine.Rigidbody:set_linearVelocity (UnityEngine.Vector3)
PurrNet.Prediction.PredictedRigidbody:OnPreSetup () (at ./Library/PackageCache/dev.purrnet.purrdiction@6f1a9a1736d0/Runtime/UnityPhysics/PredictedRigidbody.cs:85)
PurrNet.Prediction.PredictionManager:RegisterInstance (UnityEngine.GameObject,PurrNet.Prediction.PredictedObjectID,System.Nullable`1<PurrNet.PlayerID>,bool) (at ./Library/PackageCache/dev.purrnet.purrdiction@6f1a9a1736d0/Runtime/Core/PredictionManager.cs:256)
PurrNet.Prediction.PredictedHierarchy:RegisterSceneObject (UnityEngine.GameObject,int) (at ./Library/PackageCache/dev.purrnet.purrdiction@6f1a9a1736d0/Runtime/Hierarchy/PredictedHierarchy.cs:233)
PurrNet.Prediction.PredictionManager:OnEarlySpawn () (at ./Library/PackageCache/dev.purrnet.purrdiction@6f1a9a1736d0/Runtime/Core/PredictionManager.cs:168)
PurrNet.NetworkIdentity:TriggerEarlySpawnEvent (bool) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/Components/NetworkIdentity/NetworkIdentity.cs:1144)
PurrNet.Modules.HierarchyV2:RegisterIdentity (PurrNet.NetworkIdentity,bool) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:1451)
PurrNet.Modules.HierarchyV2:SpawnSceneObject (System.Collections.Generic.List`1<PurrNet.NetworkIdentity>) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:1094)
PurrNet.Modules.HierarchyV2:SetupSceneObjects (UnityEngine.SceneManagement.Scene) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:129)
PurrNet.Modules.HierarchyV2:.ctor (PurrNet.NetworkManager,PurrNet.SceneID,UnityEngine.SceneManagement.Scene,PurrNet.Modules.ScenePlayersModule,PurrNet.Modules.PlayersManager,bool) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/HierarchyV2/HierarchyV2.cs:71)
PurrNet.Modules.HierarchyFactory:OnPreSceneLoaded (PurrNet.SceneID,bool) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/HierarchyV2/HierarchyFactory.cs:98)
PurrNet.Modules.ScenesModule:AddScene (UnityEngine.SceneManagement.Scene,PurrNet.Modules.PurrSceneSettings,PurrNet.SceneID) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/Scenes/ScenesModule.cs:127)
PurrNet.Modules.ScenesModule:SceneManagerOnSceneLoaded (UnityEngine.SceneManagement.Scene,UnityEngine.SceneManagement.LoadSceneMode) (at ./Library/PackageCache/dev.purrnet.purrnet@56588edd374f/Runtime/CoreModules/Scenes/ScenesModule.cs:362)
UnityEngine.SceneManagement.SceneManager:Internal_SceneLoaded (UnityEngine.SceneManagement.Scene,UnityEngine.SceneManagement.LoadSceneMode)
```