### PR TITLE
Add RemoveAllListeners() to PredictedEvent

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedEvent.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedEvent.cs
@@ -27,6 +27,11 @@ namespace PurrNet.Prediction
             onInvoke -= action;
         }
 
+        public void RemoveAllListeners()
+        {
+            onInvoke = null;
+        }
+
         public void Invoke()
         {
             if (_isServer)


### PR DESCRIPTION
Small QoL addition I don't think many will use, but I find myself using often enough with the normal `UnityEvent`.

- Add `RemoveAllListeners()` to `PredictedEvent`