### PR TITLE
fix: add `LocalPhysics` com ponent

### DIFF
--- a/Assets/PurrDiction/Examples/SimpleSetup.unity
+++ b/Assets/PurrDiction/Examples/SimpleSetup.unity
@@ -523,6 +523,155 @@ Transform:
   m_Children: []
   m_Father: {fileID: 457991333}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1541967316
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1541967321}
+  - component: {fileID: 1541967320}
+  - component: {fileID: 1541967319}
+  - component: {fileID: 1541967318}
+  - component: {fileID: 1541967317}
+  - component: {fileID: 1541967322}
+  m_Layer: 0
+  m_Name: Cube
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!54 &1541967317
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 1
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!65 &1541967318
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &1541967319
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &1541967320
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &1541967321
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 4.38, y: 5, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1541967322
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1541967316}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cb4336e7633d7334295117c7d05d8a05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1558659894
 GameObject:
   m_ObjectHideFlags: 0
@@ -880,3 +1029,4 @@ SceneRoots:
   - {fileID: 457991333}
   - {fileID: 1997087629}
   - {fileID: 1839018146}
+  - {fileID: 1541967321}

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -808,6 +808,8 @@ namespace PurrNet.Prediction
         }
 
         private ulong _lastVerifiedTick = 1;
+        public event Action onStartingToRollback;
+        public event Action onRollbackFinished;
 
         private void OnPostTick()
         {
@@ -819,6 +821,7 @@ namespace PurrNet.Prediction
                 return;
             }
 
+            onStartingToRollback?.Invoke();
             UpdateInterpolation(false);
 
             isSimulating = true;
@@ -859,6 +862,7 @@ namespace PurrNet.Prediction
             isSimulating = false;
 
             TickBandwidthProfiler.MarkEndOfTick();
+            onRollbackFinished?.Invoke();
         }
 
         private void UpdateInterpolation(bool accumulateError)

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+
+namespace PurrNet.Prediction
+{
+    public class LocalPhysics : MonoBehaviour
+    {
+#if UNITY_PHYSICS_3D
+        private PredictionManager _manager;
+        private Rigidbody[] _rigidbodies;
+        private UnityRigidbodyState[] _state;
+
+        private void Awake()
+        {
+            _rigidbodies = GetComponentsInChildren<Rigidbody>();
+            _state = new UnityRigidbodyState[_rigidbodies.Length];
+        }
+
+        private void Start()
+        {
+            if (PredictionManager.TryGetInstance(gameObject.scene.handle, out var manager))
+            {
+                _manager = manager;
+                _manager.onStartingToRollback += OnStartingToRollback;
+                _manager.onRollbackFinished += OnRollbackFinished;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (!_manager)
+                return;
+
+            _manager.onStartingToRollback -= OnStartingToRollback;
+            _manager.onRollbackFinished -= OnRollbackFinished;
+        }
+
+        private void OnStartingToRollback()
+        {
+            for (int i = 0; i < _rigidbodies.Length; i++)
+            {
+                _state[i] = new UnityRigidbodyState(_rigidbodies[i]);
+                _rigidbodies[i].isKinematic = true;
+            }
+        }
+
+        private void OnRollbackFinished()
+        {
+            for (int i = 0; i < _rigidbodies.Length; i++)
+            {
+                var state = _state[i];
+                var rb = _rigidbodies[i];
+                rb.isKinematic = state.isKinematic;
+#if UNITY_6000
+                rb.linearVelocity = state.linearVelocity;
+#else
+                rb.velocity = state.linearVelocity;
+#endif
+                rb.angularVelocity = state.angularVelocity;
+                if (state.isSleeping)
+                    rb.Sleep();
+                else rb.WakeUp();
+            }
+        }
+#endif
+    }
+}

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics.cs.meta
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cb4336e7633d7334295117c7d05d8a05

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbodyState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbodyState.cs
@@ -15,6 +15,19 @@ namespace PurrNet.Prediction
             return $"LinearVelocity: {linearVelocity}\nAngularVelocity: {angularVelocity}\nIsKinematic: {isKinematic}\nIsSleeping: {isSleeping}";
         }
 
+#if UNITY_PHYSICS_3D
+        public UnityRigidbodyState(Rigidbody rigidbody)
+        {
+#if UNITY_6000
+            linearVelocity = rigidbody.linearVelocity;
+#else
+            linearVelocity = rigidbody.velocity;
+#endif
+            angularVelocity = rigidbody.angularVelocity;
+            isKinematic = rigidbody.isKinematic;
+            isSleeping = rigidbody.IsSleeping();
+        }
+#endif
         public void Dispose() { }
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added lifecycle hooks around rollback, enabling custom logic to run before rollback starts and after it finishes.
  * Introduced a Unity component that snapshots child rigidbodies during prediction rollbacks, makes them kinematic, then restores their state afterward to prevent physics glitches.
  * Improved compatibility across Unity versions, automatically handling velocity APIs where needed.
* Improvements
  * More reliable local physics behavior during rollbacks, reducing unintended motion and ensuring bodies correctly sleep/wake after restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->