### PR TITLE
Fixes IL processor hanging on certain references

### DIFF
--- a/Assets/PurrDiction/Codegen/PredictionProcessor.cs
+++ b/Assets/PurrDiction/Codegen/PredictionProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using JetBrains.Annotations;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
@@ -161,7 +162,16 @@ namespace Purrdiction.Codegen
             if (name.StartsWith("UnityEngine."))
                 return false;
 
-            return !name.Contains("Editor");
+            if (name.Contains("Editor"))
+                return false;
+
+            if (name.Equals("PurrNet.Prediction", StringComparison.OrdinalIgnoreCase))
+                return true;
+
+            bool referencesPurrNet = compiledAssembly.References
+                .Any(r => Path.GetFileNameWithoutExtension(r).Equals("PurrNet.Prediction", StringComparison.OrdinalIgnoreCase));
+
+            return referencesPurrNet;
         }
     }
 }


### PR DESCRIPTION
The IL post-processor does not work with certain libraries which have no relation to PurrNet.
- NuGetForUnity causes the post-processor to run indefinitely, making any project where PurrDiction and NuGetForUnity are installed together impossible to open.
- JSB (From ReactUnity) throws runtime exceptions when the IL post-processor works over it.

By outputting the results of this function, I got the following modules being processed:

<img width="804" height="523" alt="image" src="https://github.com/user-attachments/assets/388e3954-d846-4758-992a-598eac40dbea" />

Only assemblies which reference PurrNet.Prediction will be post-processed by the Prediction post processors, as if they do not reference PurrDiction, then they are unable to have any of the types that need processing included within them.

In my project, the following types were processed:
- Assembly-CSharp: This is my base assembly where PurrDiction was installed, so references it.
- PurrNet.Prediction.Prebuild: References PurrNet.Prediction
- PurrNet.Prediction: Is PurrNet.Prediction, so is itself procesed.
- PurrDiction.Examples: References PurrNet.Prediction

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes & Refactor**
  * Enhanced prediction processor eligibility logic with improved assembly filtering, better exclusion handling, and more precise reference validation for accurate prediction processing across assemblies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->