### PR TITLE
feat: OnBeforeRegisterInstance and IPredictedObjectInitializer for DI

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/IPredictedObjectInitializer.cs
+++ b/Assets/PurrDiction/Runtime/Core/IPredictedObjectInitializer.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace PurrNet.Prediction
+{
+    /// <summary>
+    /// Implement on a component to receive initialization callback
+    /// before PredictedIdentity components are registered.
+    /// Use this to add PredictedIdentity components via DI.
+    /// </summary>
+    public interface IPredictedObjectInitializer
+    {
+        /// <summary>
+        /// Called after GameObject instantiation but before PredictedIdentity registration.
+        /// Add your PredictedIdentity components here - they will be picked up by GetComponentsInChildren.
+        /// </summary>
+        void OnBeforePredictedRegister(PredictedSpawnContext context);
+    }
+}

--- a/Assets/PurrDiction/Runtime/Core/IPredictedObjectInitializer.cs.meta
+++ b/Assets/PurrDiction/Runtime/Core/IPredictedObjectInitializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b354d3eaf41dc3b4587d8872fb4306c0

--- a/Assets/PurrDiction/Runtime/Core/PredictedSpawnContext.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedSpawnContext.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+
+namespace PurrNet.Prediction
+{
+    /// <summary>
+    /// Context passed to initializers before PredictedIdentity registration.
+    /// Contains all information needed for DI decisions.
+    /// </summary>
+    public readonly struct PredictedSpawnContext
+    {
+        public readonly PredictionManager PredictionManager;
+        public readonly PredictedObjectID ObjectId;
+        public readonly PlayerID? Owner;
+        public readonly bool IsServer;
+        public readonly bool IsClient;
+        public readonly bool IsLocalPlayer;
+
+        public PredictedSpawnContext(
+            PredictionManager predictionManager,
+            PredictedObjectID objectId,
+            PlayerID? owner)
+        {
+            PredictionManager = predictionManager;
+            ObjectId = objectId;
+            Owner = owner;
+            IsServer = predictionManager.cachedIsServer;
+            IsClient = predictionManager.isClient;
+            IsLocalPlayer = owner.HasValue &&
+                            predictionManager.isSpawned &&
+                            owner == predictionManager.localPlayer;
+        }
+    }
+}

--- a/Assets/PurrDiction/Runtime/Core/PredictedSpawnContext.cs.meta
+++ b/Assets/PurrDiction/Runtime/Core/PredictedSpawnContext.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ab7f490b41911541a7b97cc186e6729

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -294,6 +294,27 @@ namespace PurrNet.Prediction
 
         public void RegisterInstance(GameObject go, PredictedObjectID objectID, PlayerID? owner, bool reset)
         {
+            var context = new PredictedSpawnContext(this, objectID, owner);
+
+            OnBeforeRegisterInstance?.Invoke(go, context);
+
+            var initializers = ListPool<IPredictedObjectInitializer>.Instantiate();
+            go.GetComponentsInChildren(true, initializers);
+
+            for (var i = 0; i < initializers.Count; i++)
+            {
+                try
+                {
+                    initializers[i].OnBeforePredictedRegister(context);
+                }
+                catch (Exception e)
+                {
+                    PurrLogger.LogError($"Error in IPredictedObjectInitializer: {e}", go);
+                }
+            }
+
+            ListPool<IPredictedObjectInitializer>.Destroy(initializers);
+
             var components = ListPool<PredictedIdentity>.Instantiate();
             go.GetComponentsInChildren(true, components);
             int count = components.Count;
@@ -1310,5 +1331,7 @@ namespace PurrNet.Prediction
             pid = default;
             return false;
         }
+
+        public static event Action<GameObject, PredictedSpawnContext> OnBeforeRegisterInstance;
     }
 }


### PR DESCRIPTION
Made event and IPredictedObjectInitializer calls with some spawn context useful for DI solutions

Usage example:

```csharp
public class PlayerLifetimeScope : LifetimeScope, IPredictedObjectInitializer
{
    [SerializeField] private PlayerControllerDependency.Dependencies PlayerControllerDependencies = null!;

    private PredictedSpawnContext ctx;
    private bool initialized;

    protected override void Awake()
    {
        autoRun = false;
    }

    public void OnBeforePredictedRegister(PredictedSpawnContext context)
    {
        ctx = context;
        initialized = true;
        Build();
    }

    protected override void Configure(IContainerBuilder b)
    {
        if (!initialized)
        {
            Debug.LogError("Configure called without spawn context!");
            return;
        }

        b.RegisterPlayerController(this, ref ctx, PlayerControllerDependencies);
    }
}

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an extensibility mechanism allowing developers to customize predicted object initialization during spawning
  * New callback interface enables component injection before predicted object registration
  * Context information provided to initializers for conditional dependency injection logic

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->