### PR TITLE
Add LocalPhysics2D equivalent and fix static Rigidbody2D warnings

### DIFF
--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
@@ -1,5 +1,4 @@
-﻿#define UNITY_PHYSICS_2D
-using UnityEngine;
+﻿using UnityEngine;
 
 namespace PurrNet.Prediction
 {

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
@@ -1,0 +1,80 @@
+﻿#define UNITY_PHYSICS_2D
+using UnityEngine;
+
+namespace PurrNet.Prediction
+{
+    public class LocalPhysics2D : MonoBehaviour
+    {
+#if UNITY_PHYSICS_2D
+        private PredictionManager _manager;
+        private Rigidbody2D[] _rigidbodies;
+        private UnityRigidbody2DState[] _state;
+
+        private void Awake()
+        {
+            _rigidbodies = GetComponentsInChildren<Rigidbody2D>();
+            _state = new UnityRigidbody2DState[_rigidbodies.Length];
+        }
+
+        private void Start()
+        {
+            if (PredictionManager.TryGetInstance(gameObject.scene.handle, out var manager))
+            {
+                _manager = manager;
+                _manager.onStartingToRollback += OnStartingToRollback;
+                _manager.onRollbackFinished += OnRollbackFinished;
+            }
+        }
+
+        private void OnDestroy()
+        {
+            if (!_manager)
+                return;
+
+            _manager.onStartingToRollback -= OnStartingToRollback;
+            _manager.onRollbackFinished -= OnRollbackFinished;
+        }
+
+        private void OnStartingToRollback()
+        {
+            for(int i = 0; i < _rigidbodies.Length; i++)
+            {
+                var rb = _rigidbodies[i];
+
+                _state[i] = new UnityRigidbody2DState
+                {
+                    linearVelocity = rb.linearVelocity,
+                    angularVelocity = rb.angularVelocity,
+                    bodyType = rb.bodyType,
+                    isSleeping = rb.IsSleeping()
+                };
+
+                rb.bodyType = RigidbodyType2D.Kinematic;
+
+                //reset velocities as setting bodyType to Kinematic does not reset them like on 3d rigidbodies
+                rb.linearVelocity = Vector2.zero;
+                rb.angularVelocity = default;
+            }
+        }
+
+        private void OnRollbackFinished()
+        {
+            for (int i = 0; i < _rigidbodies.Length; i++)
+            {
+                var state = _state[i];
+                var rb = _rigidbodies[i];
+                rb.bodyType = state.bodyType;
+                //Rigidbody2D can have velocity even when Kinematic. We only skip when bodyType is Static
+                if (state.bodyType == RigidbodyType2D.Static)
+                    continue;
+
+                rb.linearVelocity = state.linearVelocity;
+                rb.angularVelocity = state.angularVelocity;
+                if (state.isSleeping)
+                    rb.Sleep();
+                else rb.WakeUp();
+            }
+        }
+#endif
+    }
+}

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
@@ -40,7 +40,7 @@ namespace PurrNet.Prediction
             {
                 var rb = _rigidbodies[i];
 
-                _state[i] = new UnityRigidbody2DState( rb );
+                _state[i] = new UnityRigidbody2DState(rb);
 
                 rb.bodyType = RigidbodyType2D.Kinematic;
 
@@ -60,9 +60,9 @@ namespace PurrNet.Prediction
             {
                 var state = _state[i];
                 var rb = _rigidbodies[i];
-                rb.bodyType = state.bodyType;
+                rb.bodyType = (RigidbodyType2D) state.bodyType;
                 //Rigidbody2D can have velocity even when Kinematic. We only skip when bodyType is Static
-                if (state.bodyType == RigidbodyType2D.Static)
+                if (rb.bodyType == RigidbodyType2D.Static)
                     continue;
 
 #if UNITY_6000
@@ -77,5 +77,5 @@ namespace PurrNet.Prediction
             }
         }
 #endif
-            }
-        }
+    }
+}

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿#define UNITY_PHYSICS_2D
+using UnityEngine;
 
 namespace PurrNet.Prediction
 {
@@ -40,18 +41,16 @@ namespace PurrNet.Prediction
             {
                 var rb = _rigidbodies[i];
 
-                _state[i] = new UnityRigidbody2DState
-                {
-                    linearVelocity = rb.linearVelocity,
-                    angularVelocity = rb.angularVelocity,
-                    bodyType = rb.bodyType,
-                    isSleeping = rb.IsSleeping()
-                };
+                _state[i] = new UnityRigidbody2DState( rb );
 
                 rb.bodyType = RigidbodyType2D.Kinematic;
 
                 //reset velocities as setting bodyType to Kinematic does not reset them like on 3d rigidbodies
-                rb.linearVelocity = Vector2.zero;
+#if UNITY_6000
+                rb.linearVelocity = default;
+#else
+                rb.velocity = default;
+#endif
                 rb.angularVelocity = default;
             }
         }
@@ -67,7 +66,11 @@ namespace PurrNet.Prediction
                 if (state.bodyType == RigidbodyType2D.Static)
                     continue;
 
+#if UNITY_6000
                 rb.linearVelocity = state.linearVelocity;
+#else
+                rb.velocity = state.linearVelocity;
+#endif
                 rb.angularVelocity = state.angularVelocity;
                 if (state.isSleeping)
                     rb.Sleep();
@@ -75,5 +78,5 @@ namespace PurrNet.Prediction
             }
         }
 #endif
-    }
-}
+            }
+        }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs.meta
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/LocalPhysics2D.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5c84fc9396b9b8647b4d7632f64ca613

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
@@ -68,13 +68,14 @@ namespace PurrNet.Prediction
                 _eventMask = PhysicsEventMask.None;
         }
 
-
         protected override UnityRigidbody2DState GetInitialState()
         {
             return new UnityRigidbody2DState
             {
                 linearVelocity = linearVelocity,
                 angularVelocity = angularVelocity,
+                bodyType = (int) _rigidbody.bodyType,
+                isSleeping = _rigidbody.IsSleeping(),
 #if UNITY_6000
                 linearDamping = _rigidbody.linearDamping,
 #endif
@@ -85,6 +86,8 @@ namespace PurrNet.Prediction
         {
             state.linearVelocity = linearVelocity;
             state.angularVelocity = angularVelocity;
+            state.bodyType = (int) _rigidbody.bodyType;
+            state.isSleeping = _rigidbody.IsSleeping();
 #if UNITY_6000
             state.linearDamping = _rigidbody.linearDamping;
 #endif
@@ -92,8 +95,21 @@ namespace PurrNet.Prediction
 
         protected override void SetUnityState(UnityRigidbody2DState state)
         {
-            linearVelocity = state.linearVelocity;
-            angularVelocity = state.angularVelocity;
+            _rigidbody.bodyType = (RigidbodyType2D) state.bodyType;
+            
+            if( _rigidbody.bodyType != RigidbodyType2D.Static)
+            { 
+                linearVelocity = state.linearVelocity;
+                angularVelocity = state.angularVelocity;
+            }
+
+            if (_rigidbody.IsSleeping() != state.isSleeping)
+            { 
+                if ( state.isSleeping)
+                    _rigidbody.Sleep();
+                else 
+                    _rigidbody.WakeUp();
+            }
 #if UNITY_6000
             _rigidbody.linearDamping = state.linearDamping;
 #endif

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
@@ -83,13 +83,6 @@ namespace PurrNet.Prediction
 
         protected override void GetUnityState(ref UnityRigidbody2DState state)
         {
-            if (_rigidbody.bodyType != RigidbodyType2D.Dynamic)
-            {
-                state.linearVelocity = default;
-                state.angularVelocity = default;
-                return;
-            }
-
             state.linearVelocity = linearVelocity;
             state.angularVelocity = angularVelocity;
 #if UNITY_6000
@@ -99,9 +92,6 @@ namespace PurrNet.Prediction
 
         protected override void SetUnityState(UnityRigidbody2DState state)
         {
-            if (_rigidbody.bodyType != RigidbodyType2D.Dynamic)
-                return;
-
             linearVelocity = state.linearVelocity;
             angularVelocity = state.angularVelocity;
 #if UNITY_6000
@@ -210,30 +200,46 @@ namespace PurrNet.Prediction
 
         public Vector2 linearVelocity
         {
+            get
+            {
 #if UNITY_6000
-            get => _rigidbody.linearVelocity;
-            set => _rigidbody.linearVelocity = value;
+                return _rigidbody.linearVelocity;
 #else
-            get => _rigidbody.velocity;
-            set => _rigidbody.velocity = value;
+                return _rigidbody.velocity;
 #endif
+            }
+
+            set
+            {
+                //setting linearVelocity on static Rigidbody2D logs a warning.
+                if (_rigidbody.bodyType == RigidbodyType2D.Static)
+                    return;
+
+#if UNITY_6000
+                _rigidbody.linearVelocity = value;
+#else
+                _rigidbody.velocity = value
+#endif
+            }
         }
 
         public Vector2 velocity
         {
-#if UNITY_6000
-            get => _rigidbody.linearVelocity;
-            set => _rigidbody.linearVelocity = value;
-#else
-            get => _rigidbody.velocity;
-            set => _rigidbody.velocity = value;
-#endif
+            get => linearVelocity;
+            set => linearVelocity = value;
         }
 
         public float angularVelocity
         {
             get => _rigidbody.angularVelocity;
-            set => _rigidbody.angularVelocity = value;
+            set
+            {
+                //setting angularVelocity on static Rigidbody2D logs a warning.
+                if (_rigidbody.bodyType == RigidbodyType2D.Static)
+                    return;
+
+                _rigidbody.angularVelocity = value;
+            }
         }
 
         /// <summary>

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
@@ -218,7 +218,7 @@ namespace PurrNet.Prediction
 #if UNITY_6000
                 _rigidbody.linearVelocity = value;
 #else
-                _rigidbody.velocity = value
+                _rigidbody.velocity = value;
 #endif
             }
         }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
@@ -7,11 +7,32 @@ namespace PurrNet.Prediction
         public Vector2 linearVelocity;
         public float angularVelocity;
         public float linearDamping;
+        public RigidbodyType2D bodyType;
+        public bool isSleeping;
 
         public override string ToString()
         {
-            return $"(linearVelocity: {linearVelocity}, angularVelocity: {angularVelocity})";
+            return
+                $"LinearVelocity: {linearVelocity}\n" +
+                $"AngularVelocity: {angularVelocity}\n" +
+                $"BodyType: {bodyType}\n" +
+                $"IsSleeping:{isSleeping}";
         }
+
+#if UNITY_PHYSICS_2D
+        public UnityRigidbody2DState( Rigidbody2D rigidbody )
+        {
+#if UNITY_6000
+            linearVelocity = rigidbody.linearVelocity;
+#else
+            linearVelocity = rigidbody.velocity;
+#endif
+            angularVelocity = rigidbody.angularVelocity;
+            linearDamping = rigidbody.linearDamping;
+            bodyType = rigidbody.bodyType;
+            isSleeping = rigidbody.IsSleeping();
+        }
+#endif
 
         public void Dispose() { }
     }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
@@ -7,7 +7,7 @@ namespace PurrNet.Prediction
         public Vector2 linearVelocity;
         public float angularVelocity;
         public float linearDamping;
-        public RigidbodyType2D bodyType;
+        public int bodyType;
         public bool isSleeping;
 
         public override string ToString()
@@ -29,7 +29,7 @@ namespace PurrNet.Prediction
             linearVelocity = rigidbody.velocity;
 #endif
             angularVelocity = rigidbody.angularVelocity;
-            bodyType = rigidbody.bodyType;
+            bodyType = (int) rigidbody.bodyType;
             isSleeping = rigidbody.IsSleeping();
         }
 #endif

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
@@ -24,11 +24,11 @@ namespace PurrNet.Prediction
         {
 #if UNITY_6000
             linearVelocity = rigidbody.linearVelocity;
+            linearDamping = rigidbody.linearDamping;
 #else
             linearVelocity = rigidbody.velocity;
 #endif
             angularVelocity = rigidbody.angularVelocity;
-            linearDamping = rigidbody.linearDamping;
             bodyType = rigidbody.bodyType;
             isSleeping = rigidbody.IsSleeping();
         }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbody2DState.cs
@@ -16,7 +16,7 @@ namespace PurrNet.Prediction
                 $"LinearVelocity: {linearVelocity}\n" +
                 $"AngularVelocity: {angularVelocity}\n" +
                 $"BodyType: {bodyType}\n" +
-                $"IsSleeping:{isSleeping}";
+                $"IsSleeping: {isSleeping}";
         }
 
 #if UNITY_PHYSICS_2D

--- a/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbodyState.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/UnityRigidbodyState.cs
@@ -12,7 +12,11 @@ namespace PurrNet.Prediction
 
         public override string ToString()
         {
-            return $"LinearVelocity: {linearVelocity}\nAngularVelocity: {angularVelocity}\nIsKinematic: {isKinematic}\nIsSleeping: {isSleeping}";
+            return 
+                $"LinearVelocity: {linearVelocity}\n" +
+                $"AngularVelocity: {angularVelocity}\n" +
+                $"IsKinematic: {isKinematic}\n" +
+                $"IsSleeping: {isSleeping}";
         }
 
 #if UNITY_PHYSICS_3D


### PR DESCRIPTION
Fix: Don`t set linearVelocity or angularVelocity of static Rigidbody2D as it logs warnings

Added: LocalPhysics2D.cs

Added: Required fields in UnityRigidbody2DState.cs for LocalPhysics2D.cs

Changed: Improved readability of ToString in UnityRigidbodyState.cs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a 2D physics component that snapshots and restores rigidbody state during rollback (velocities, body type, and sleep state).

* **Improvements**
  * Safer handling to avoid modifying static/non-dynamic rigidbodies.
  * Expanded rigidbody state tracking to include body type and sleeping and improved debug/state output formatting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->