### PR TITLE
Improved random floating point generation

### DIFF
--- a/Assets/PurrDiction/Runtime/Random/PredictedRandom.cs
+++ b/Assets/PurrDiction/Runtime/Random/PredictedRandom.cs
@@ -1,11 +1,13 @@
 using PurrNet.Packing;
+using System;
 
 namespace PurrNet.Prediction
 {
     public struct PredictedRandom : IPackedAuto
     {
         public uint seed;
-
+        const uint MCG_MULTIPLIER_CONSTANT = 0x93D765DD;
+        const uint FLOAT_EXPONENT_MASK = 0x3F800000;
         public override string ToString()
         {
             return $"PredictedRandom(seed: {seed})";
@@ -22,7 +24,7 @@ namespace PurrNet.Prediction
             seed ^= seed << 13;
             seed ^= seed >> 17;
             seed ^= seed << 5;
-            return seed * 0x85EBCA6Bu;
+            return seed * MCG_MULTIPLIER_CONSTANT;
         }
 
         // Generates a random integer in the range [min, max)
@@ -40,19 +42,19 @@ namespace PurrNet.Prediction
         // Generates a random float in the range [0, 1)
         public float NextFloat()
         {
-            return Next() / (float)uint.MaxValue;
+            return BitConverter.Int32BitsToSingle((int)((Next() >> 9) | FLOAT_EXPONENT_MASK)) - 1.0f;
         }
 
         // Generates a random sfloat in the range [0, 1)
         public sfloat NextSFloat()
         {
-            return sfloat.Abs((int)Next() / (sfloat)int.MaxValue);
+            return sfloat.FromRaw((Next() >> 9) | FLOAT_EXPONENT_MASK) - sfloat.one;
         }
 
         // Generates a random sfloat in the range [0, 1)
         public FP NextFP()
         {
-            return (FP)Next() / 4294967296.0;
+            return FP.FromRaw((long)((ulong)Next() >> MathFP.Shift));
         }
 
         // Generates a random float in the range [min, max)

--- a/Assets/PurrDiction/Runtime/Random/PredictedRandom.cs
+++ b/Assets/PurrDiction/Runtime/Random/PredictedRandom.cs
@@ -6,7 +6,7 @@ namespace PurrNet.Prediction
     public struct PredictedRandom : IPackedAuto
     {
         public uint seed;
-        const uint MCG_MULTIPLIER_CONSTANT = 0x93D765DD;
+        const uint LCG_MULTIPLIER_CONSTANT = 0x915f77f5;
         const uint FLOAT_EXPONENT_MASK = 0x3F800000;
         public override string ToString()
         {
@@ -24,7 +24,9 @@ namespace PurrNet.Prediction
             seed ^= seed << 13;
             seed ^= seed >> 17;
             seed ^= seed << 5;
-            return seed * MCG_MULTIPLIER_CONSTANT;
+            seed *= LCG_MULTIPLIER_CONSTANT;
+            seed++;
+            return seed;
         }
 
         // Generates a random integer in the range [min, max)
@@ -54,7 +56,7 @@ namespace PurrNet.Prediction
         // Generates a random sfloat in the range [0, 1)
         public FP NextFP()
         {
-            return FP.FromRaw((long)((ulong)Next() >> MathFP.Shift));
+            return FP.FromRaw(Next());
         }
 
         // Generates a random float in the range [min, max)

--- a/Assets/PurrDictionTests/OutputRandomNumbersTest.cs
+++ b/Assets/PurrDictionTests/OutputRandomNumbersTest.cs
@@ -1,0 +1,57 @@
+using UnityEngine;
+
+namespace PurrNet.Prediction.Tests
+{
+    public class OutputRandomNumbersTest : MonoBehaviour
+    {
+        public PredictedRandom random;
+        public int Seed = 12345;
+        public int NumberToOutput = 10;
+        void Awake()
+        {
+            random = PredictedRandom.Create((uint)Seed);
+        }
+        void Update()
+        {
+            if (Input.GetKeyDown(KeyCode.F))
+            {
+                OutputRandomFloats();
+            }
+            if (Input.GetKeyDown(KeyCode.G))
+            {
+                OutputRandomSFloats();
+            }
+            if (Input.GetKeyDown(KeyCode.H))
+            {
+                OutputRandomFPs();
+            }
+        }
+        void OutputRandomFloats()
+        {
+            Debug.Log($"Outputting {NumberToOutput} random floats.");
+            for (int i = 0; i < NumberToOutput; i++)
+            {
+                Debug.Log(random.NextFloat());
+            }
+            Debug.Log($"Finished random float test.");
+        }
+        void OutputRandomSFloats()
+        {
+            Debug.Log($"Outputting {NumberToOutput} random sfloats.");
+            for (int i = 0; i < NumberToOutput; i++)
+            {
+                Debug.Log(random.NextSFloat());
+            }
+            Debug.Log($"Finished random sfloat test.");
+        }
+        void OutputRandomFPs()
+        {
+            Debug.Log($"Outputting {NumberToOutput} random FPs.");
+            for (int i = 0; i < NumberToOutput; i++)
+            {
+                Debug.Log(random.NextFP());
+            }
+            Debug.Log($"Finished random FP test.");
+        }
+    }
+}

--- a/Assets/PurrDictionTests/OutputRandomNumbersTest.cs.meta
+++ b/Assets/PurrDictionTests/OutputRandomNumbersTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd323ca92ecdc3943b8356d47d7816e0


### PR DESCRIPTION
I have changed the floating point random generation to rely solely on bitwise operations and simple arithmetic in order to speed up floating point generation. The trick being used here is the fact that a 32-bit floating point number with a sign + exponent of 0 0111 1111 is always going to be in the range [1, 2). Then, a simple subtraction will result in a number in the range [0,1). 
(To maximise entropy, a right shift is used to drop the least significant bits, as they are the most predictable.)
This has the added advantage of making it possible for the NextFloat to output 0.
I also changed the random output to incorporate an LCG step in order to ensure that NextFP can indeed output 0 as described in the summary (this was previously impossible, even using the new float conversion tricks).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test utility for validating random number generation across multiple output formats.

* **Chores**
  * Optimized random number generation algorithm and output conversion methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->