### PR TITLE
fix: enforce maxEntries on History fast append path

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/History.cs
+++ b/Assets/PurrDiction/Runtime/Core/History.cs
@@ -106,6 +106,9 @@ namespace PurrNet.Prediction
             if (m_data.Count == 0 || tick > m_data[^1].Tick)
             {
                 m_data.Add(entry);
+
+                if (m_maxCount > 0)
+                    TryToDownsize();
                 return;
             }
 


### PR DESCRIPTION
## Bug

`History<T>.Write()` has two paths: fast append (sequential ticks) and out-of-order insert. Only the insert path called `TryToDownsize()`. The fast append path — which handles 99.9%+ of writes — skipped it, so `maxEntries` was never enforced during normal operation.

On clients this is masked because `ClearPast()`/`ClearFuture()` get called during reconciliation. On dedicated servers with 0 connected players, no reconciliation occurs, so history lists grow unbounded.

## Impact

Our IL2CPP Linux dedicated server (Boehm GC) was growing ~194 MB/hour with a single idle ship. The server would OOM kill at ~11 GB after running overnight. After this fix, GC heap stabilized at 7 MB.

## Fix

Added `if (m_maxCount > 0) TryToDownsize();` to the fast append path, matching the existing insert path behavior. The fast path optimization is preserved — it still avoids the `Find()` binary search.

## Additional note

`PredictedIdentityStatefull.SaveStateInHistory()` skips the equality check for pure value-type states (`IsReferenceOrContainsReferences<STATE>()` returns false), so it writes to history every single tick even when the state hasn't changed. On a server with idle objects this means 30 identical entries per second per component, all of which would normally be trimmed by `maxEntries` — if it were enforced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where history entries were not being properly trimmed when the maximum count was exceeded during write operations, ensuring memory usage remains within configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->