### PR TITLE
Convenience casting PredictedObjectID to/from uint

### DIFF
--- a/Assets/PurrDiction/Runtime/Hierarchy/PredictedObjectID.cs
+++ b/Assets/PurrDiction/Runtime/Hierarchy/PredictedObjectID.cs
@@ -13,6 +13,16 @@ namespace PurrNet.Prediction
             this.instanceId = instanceId;
         }
 
+        public static implicit operator uint(PredictedObjectID id)
+        {
+            return id.instanceId.value;
+        }
+
+        public static explicit operator PredictedObjectID(uint value)
+        {
+            return new PredictedObjectID(value);
+        }
+
         public GameObject GetGameObject(PredictionManager manager)
         {
             return manager.hierarchy.GetGameObject(this);


### PR DESCRIPTION
Simple conversion operators for implicit PredictedObjectID → uint and explicit uint → PredictedObjectID.

Example:

```csharp
PredictedObjectID id = (PredictedObjectID)42;
uint raw = id;  
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type interoperability for internal object identifiers, enabling more flexible conversions within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->