### PR TITLE
Unseal StaticPredictedIdentity

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/StaticPredictedIdentity.cs
+++ b/Assets/PurrDiction/Runtime/Core/StaticPredictedIdentity.cs
@@ -3,7 +3,7 @@ using PurrNet.Packing;
 
 namespace PurrNet.Prediction
 {
-    public sealed class StaticPredictedIdentity : PredictedIdentity
+    public class StaticPredictedIdentity : PredictedIdentity
     {
         public override void WriteFirstInput(ulong localTick, BitPacker packer) { }
 


### PR DESCRIPTION
Allows inheriting a PredictedIdentity with no state or input. Convenient when passing around entities that both contain domain info and must have a predicted ID.

This is essentially a convenience that avoids having to add a domain-specific component as well as a StaticPredictedIdentity to a Game Object. In this case, you'd pass around both the domain-specific component e.g. `TriggerArea`  and its associated predicted ID. Alternatively, you could pass the domain component and use `PredictionManager.TryGetClosestPredictedID(myTriggerArea, out var triggerAreaId)` or similar.

Unsealing StaticPredictedIdentity means that you could use TriggerArea and its domain-specific fields as well as its `PredictedComponentID id` field.