### PR TITLE
Adds a simple RespawnPlayer function to PredictedPlayerSpawner.

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
@@ -191,5 +191,17 @@ namespace PurrNet.Prediction
             currentState[player] = newPlayer.Value;
             predictionManager.SetOwnership(newPlayer, player);
         }
-    }
+
+        public void RespawnPlayer(PlayerID player)
+        {
+            if (!enabled) return;
+
+            if (currentState.TryGetValue(player, out var playerID))
+            {
+                hierarchy.Delete(playerID);
+                currentState.Remove(player);
+            }
+
+            OnPlayerLoadedScene(player);
+        }
 }


### PR DESCRIPTION
Adds a `RespawnPlayer(PlayerID player)` helper to `PredictedPlayerSpawner` to make it easier for devs to just reference spawners directly:

```cs
        [SerializeField] private PredictedPlayerSpawner playerSpawner;
```

and to trigger respawns in their own function like:

```cs
            playerSpawner?.RespawnPlayer(owner);
```

without needing to reference spawnpoints again in their own `GameManager`.

I was also thinking of Instancing PredictedPlayerSpawner potentially, 

```cs
    public static PredictedPlayerSpawner Instance { get; private set; }
```

but decided not to put that in for the PR, just mention it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for properly respawning players with improved state management during respawn sequences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->