### PR TITLE
Query players by raw ID

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
@@ -17,6 +17,32 @@ namespace PurrNet.Prediction
             extrapolateInput = false;
         }
 
+        public PlayerID? GetPlayer(ulong? id)
+        {
+            if (id == null) return null;
+            foreach (var p in players)
+                if (p.id == id) return p;
+            return null;
+        }
+
+        public bool TryGetPlayer(ulong? id, out PlayerID player)
+        {
+            player = default;
+
+            if (id == null) return false;
+
+            foreach (var p in players)
+            {
+                if (p.id == id)
+                {
+                    player = p;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         protected override PredictedPlayersState GetInitialState()
         {
             return new PredictedPlayersState

--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
@@ -17,23 +17,18 @@ namespace PurrNet.Prediction
             extrapolateInput = false;
         }
 
-        public PlayerID? GetPlayer(ulong? id)
-        {
-            if (id == null) return null;
-            foreach (var p in players)
-                if (p.id == id) return p;
-            return null;
-        }
+        public PlayerID? GetPlayer(ulong? id) => TryGetPlayer(id, out var player) ? player : null;
 
         public bool TryGetPlayer(ulong? id, out PlayerID player)
         {
             player = default;
 
-            if (id == null) return false;
+            if (!id.HasValue) return false;
+            var rawId = id.Value;
 
             foreach (var p in players)
             {
-                if (p.id == id)
+                if (p.id == rawId)
                 {
                     player = p;
                     return true;


### PR DESCRIPTION
Allows querying PredictedPlayers by raw `ulong` ID.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added player lookup utilities to retrieve a player by unique identifier.
  * Provided both direct retrieval and a safe "try" retrieval pattern that returns success/failure, enabling simpler null-safe checks and more robust player management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->