### PR TITLE
[PredictedPlayerSpawner] Adds devs control over when to spawn players (all and singular)

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
@@ -96,6 +96,7 @@ namespace PurrNet.Prediction
         [SerializeField] private GameObject _playerPrefab;
         [SerializeField, PurrLock] private bool _destroyOnDisconnect;
         [SerializeField] private List<Transform> spawnPoints = new List<Transform>();
+        [SerializeField] private bool _waitForSpawnCall;
 
         private void Awake() => CleanupSpawnPoints();
 
@@ -167,9 +168,17 @@ namespace PurrNet.Prediction
             if (!enabled)
                 return;
 
+            if (_waitForSpawnCall)
+                return;
+
             if (currentState.ContainsKey(player))
                 return;
 
+            SpawnPlayerInternal(player);
+        }
+
+        private void SpawnPlayerInternal(PlayerID player)
+        {
             PredictedObjectID? newPlayer;
 
             CleanupSpawnPoints();
@@ -190,6 +199,32 @@ namespace PurrNet.Prediction
 
             currentState[player] = newPlayer.Value;
             predictionManager.SetOwnership(newPlayer, player);
+        }
+
+        public void SpawnPlayer(PlayerID player)
+        {
+            if (!enabled) return;
+
+            if (currentState.ContainsKey(player))
+                return;
+
+            SpawnPlayerInternal(player);
+        }
+
+        public void SpawnAllPlayers()
+        {
+            if (!enabled || predictionManager.players == null)
+                return;
+
+            var players = predictionManager.players.players;
+
+            for (int i = 0; i < players.Count; i++)
+            {
+                var player = players[i];
+
+                if (!currentState.ContainsKey(player))
+                    SpawnPlayerInternal(player);
+            }
         }
 
         public void RespawnPlayer(PlayerID player)

--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayerSpawner.cs
@@ -237,7 +237,7 @@ namespace PurrNet.Prediction
                 currentState.Remove(player);
             }
 
-            OnPlayerLoadedScene(player);
+            SpawnPlayerInternal(player);
         }
     }
 }


### PR DESCRIPTION
Made a video about in #contributors channel on discord.

Didnt change the original logic of how players get spawned in, but added ability for devs to spawn them in manually and opting out of automatic spawning in two ways if they enable `_waitForSpawnCall`:

```cs
        [SerializeField] private PredictedPlayerSpawner _spawner;
```

By referencing `PredictedPlayerSpawner` in their `GameManager` or some other class, they can use:

```cs
        public void SpawnLocalPlayer()
        {
            if (!NetworkManager.isServerStatic || _spawner == null)
                return;

            var localPlayer = NetworkManager.main.localPlayer;

            if (localPlayer == null)
                return;

            _spawner.SpawnPlayer(localPlayer);
        }
```

as an example, or:

```cs
        public void SpawnThemAll()
        {
            if (!NetworkManager.isServerStatic || _spawner == null)
                return;

            _spawner.SpawnAllPlayers();
        }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Manual player spawn controls: spawn individual players on demand.
  * Bulk spawn action to spawn all pending players at once.
  * Configurable option to delay automatic spawning so manual triggers can be used; existing automatic behavior remains when the delay option is not enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->