### PR TITLE
PredictedHierarchy create with transform

### DIFF
--- a/Assets/PurrDiction/Runtime/Hierarchy/PredictedHierarchy.cs
+++ b/Assets/PurrDiction/Runtime/Hierarchy/PredictedHierarchy.cs
@@ -147,12 +147,14 @@ namespace PurrNet.Prediction
 
         public PredictedObjectID? Create(int prefabId, Transform transform, PlayerID? owner = null)
         {
-            return Create(prefabId, transform.position, transform.rotation, owner);
+            transform.GetPositionAndRotation(out var position, out var rotation);
+            return Create(prefabId, position, rotation, owner);
         }
 
         public PredictedObjectID? Create(GameObject prefab, Transform transform, PlayerID? owner = null)
         {
-            return Create(prefab, transform.position, transform.rotation, owner);
+            transform.GetPositionAndRotation(out var position, out var rotation);
+            return Create(prefab, position, rotation, owner);
         }
 
         public PredictedObjectID? Create(GameObject prefab, Vector3 position, Quaternion rotation, PlayerID? owner = null)

--- a/Assets/PurrDiction/Runtime/Hierarchy/PredictedHierarchy.cs
+++ b/Assets/PurrDiction/Runtime/Hierarchy/PredictedHierarchy.cs
@@ -145,6 +145,16 @@ namespace PurrNet.Prediction
             return Create(prefab, owner);
         }
 
+        public PredictedObjectID? Create(int prefabId, Transform transform, PlayerID? owner = null)
+        {
+            return Create(prefabId, transform.position, transform.rotation, owner);
+        }
+
+        public PredictedObjectID? Create(GameObject prefab, Transform transform, PlayerID? owner = null)
+        {
+            return Create(prefab, transform.position, transform.rotation, owner);
+        }
+
         public PredictedObjectID? Create(GameObject prefab, Vector3 position, Quaternion rotation, PlayerID? owner = null)
         {
             if (!predictionManager.TryGetPrefab(prefab, out var pid))


### PR DESCRIPTION
Two convenience overloads for `PredictedHierarchy.Create` using a Unity `Transform`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two new object-creation overloads that accept a Transform directly, making it easier to instantiate objects using transform position and rotation.
  * New overloads preserve the optional owner parameter and maintain existing creation behavior and return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->