### PR TITLE
fix: guard RollbackToFrame against _systems shrinking mid-iteration

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -917,7 +917,11 @@ namespace PurrNet.Prediction
             Packer<PackedInt>.Read(frame, ref _count);
             int count = _count;
 
-            for (var i = 0; i < count; ++i)
+            // Guard against _systems shrinking mid-iteration.
+            // RunReadState can trigger hierarchy deletion (via SetUnityState applying
+            // OperationType.Delete), which calls UnregisterInstance and removes entries
+            // from _systems. Using Math.Min ensures we don't access stale indices.
+            for (var i = 0; i < count && i < _systems.Count; ++i)
             {
                 var system = _systems[i];
                 if (system.isEventHandler)
@@ -930,10 +934,10 @@ namespace PurrNet.Prediction
                 system.lastVerifiedTick = stateTick;
             }
 
-            for (var i = 0; i < count; ++i)
+            for (var i = 0; i < count && i < _systems.Count; ++i)
                 _systems[i].ReadInput(inputTick, default, frame, _deltaModuleState, true);
 
-            for (var i = 0; i < count; ++i)
+            for (var i = 0; i < count && i < _systems.Count; ++i)
             {
                 var system = _systems[i];
                 if (!system.isEventHandler)


### PR DESCRIPTION
## Problem

When a predicted object with multiple components (`PredictedTransform`, `PredictedRigidbody`, custom `PredictedIdentity<TInput, TState>`) is deleted via `hierarchy.Delete()`, clients crash with cascading `ArgumentOutOfRangeException` every tick:

```
ArgumentOutOfRangeException: Index was out of range.
  at System.Collections.Generic.List`1[T].get_Item(Int32 index)
  at PurrNet.Prediction.PredictionManager.RollbackToFrame(BitPacker, UInt64, UInt64)
  at PurrNet.Prediction.PredictionManager.OnPostTick()
```

This permanently breaks all PurrDiction state replication for the rest of the session.

## Root Cause

In `RollbackToFrame()` (PredictionManager.cs line 912-945), `count` is read from the serialized frame data, then used to iterate `_systems`:

```csharp
int count = _count;  // from serialized frame

for (var i = 0; i < count; ++i)
{
    var system = _systems[i];  // _systems may have shrunk!
    system.RunReadState(...);  // can trigger hierarchy deletion
}
```

`RunReadState` on the `PredictedHierarchy` system applies `OperationType.Delete`, which calls `UnregisterInstance()` — removing entries from `_systems` while the loop is still iterating with the stale `count`. Objects with 3+ predicted components cause a larger gap between the serialized count and actual list size, reliably triggering the crash.

Objects with a single predicted component (e.g. simple projectiles) appear to survive because the count mismatch is smaller.

## Fix

Added `&& i < _systems.Count` guard to all three iteration loops in `RollbackToFrame`, ensuring the loop stops early if `_systems` shrinks during iteration rather than accessing out-of-range indices.

## Reproduction

1. Create a predicted object via `hierarchy.Create()` with 3+ predicted components
2. Server calls `hierarchy.Delete(objectId)`
3. Client receives deletion via state diff → crash

Tested with PurrNet `1.20.0-beta.53` and PurrDiction `1.3.0-beta.19` on Unity `6000.3.12f1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a potential crash that could occur during state rollback when certain objects are deleted during processing, improving stability and preventing undefined behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->