### PR TITLE
Skip player bit packer for bots

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -451,7 +451,7 @@ namespace PurrNet.Prediction
 
         protected override void OnPreObserverAdded(PlayerID player)
         {
-            if (player == localPlayer)
+            if (player == localPlayer || player.isBot)
                 return;
 
             if (localTick == 1)
@@ -467,7 +467,7 @@ namespace PurrNet.Prediction
 
         protected override void OnObserverAdded(PlayerID player)
         {
-            if (player == localPlayer)
+            if (player == localPlayer || player.isBot)
                 return;
 
             using var frame = BitPackerPool.Get();


### PR DESCRIPTION
PurrDiction does not play nice with bots added via `NetworkManager.playerModule.CreateBot()` before loading a PredictionManager. There may be more changes required for this to work in practice, but I'd love to get some feedback from the devs and others more in the know than myself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved prediction system efficiency by preventing unnecessary initialization flows when bot observers are added.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->