### PR TITLE
fix: Make PredictedIdentityEditor work with TriInspector

### DIFF
--- a/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
@@ -1,5 +1,6 @@
 using UnityEditor;
 using UnityEngine;
+using UnityEngine.UIElements;
 
 namespace PurrNet.Prediction.Editor
 {
@@ -14,6 +15,11 @@ namespace PurrNet.Prediction.Editor
 #endif
     {
         static GUIStyle _box;
+
+        public override VisualElement CreateInspectorGUI()
+        {
+            return null;
+        }
 
         public override void OnInspectorGUI()
         {


### PR DESCRIPTION
The PredictedIdentityEditor has ready made integration with TriInspector If you have TriInspector installed

```
#if TRI_INSPECTOR_PACKAGE
    public class PredictedIdentityEditor : TriInspector.Editors.TriEditor
#elif ODIN_INSPECTOR
    public class PredictedIdentityEditor : Sirenix.OdinInspector.Editor.OdinEditor
#else
    public class PredictedIdentityEditor : UnityEditor.Editor
```

But it currently causes so that if you have TriInspector installed, the PredictedIdentityEditor GUIs do not show up:
<img width="539" height="255" alt="image" src="https://github.com/user-attachments/assets/aef3fa93-f421-4575-9858-9c5d2a0b030c" />

Adding this 

```
public override VisualElement CreateInspectorGUI()
{
    return null;
}
```

fixes the issue. 

<img width="524" height="439" alt="image" src="https://github.com/user-attachments/assets/08e88eff-3716-4c1b-9b47-5f376683bf15" />

Its got something to do with the fact that TriEditor implement CreateInspectorGUI() function, and unity will prefer that path over OnInspectorGUI which makes it not run at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated editor inspector infrastructure for compatibility while preserving existing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->