### PR TITLE
Eliminate per-tick GC allocations in PredictedPlayers.GetFinalInput

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
@@ -35,32 +35,43 @@ namespace PurrNet.Prediction
 
         protected override void GetFinalInput(ref PredictedPlayersInput input)
         {
-            var toAdd = DisposableList<PlayerID>.Create(16);
-            var toRemove = DisposableList<PlayerID>.Create(16);
-
             var observers = predictionManager.observers;
-
+            var currentPlayers = currentState.players;
+        
+            bool needsAdd = false;
             for (var i = 0; i < observers.Count; i++)
             {
-                var player = observers[i];
-                if (!currentState.players.Contains(player) &&
-                    _scenePlayersModule.IsPlayerLoadedInScene(player, predictionManager.sceneId))
-                {
-                    toAdd.Add(player);
-                }
+                if (!currentPlayers.Contains(observers[i])) { needsAdd = true; break; }
             }
-
-            var playersCount = currentState.players.Count;
-            var currentPlayers = currentState.players;
-            for (var i = 0; i < playersCount; i++)
+        
+            bool needsRemove = false;
+            for (var i = 0; i < currentPlayers.Count; i++)
             {
-                var current = currentPlayers[i];
-                if (!predictionManager.IsObserver(current))
-                    toRemove.Add(current);
+                if (!predictionManager.IsObserver(currentPlayers[i])) { needsRemove = true; break; }
             }
-
-            input.addPlayers = toAdd;
-            input.removePlayers = toRemove;
+        
+            if (needsAdd)
+            {
+                var toAdd = DisposableList<PlayerID>.Create(16);
+                for (var i = 0; i < observers.Count; i++)
+                {
+                    if (!currentPlayers.Contains(observers[i]))
+                        toAdd.Add(observers[i]);
+                }
+                input.addPlayers = toAdd;
+            }
+        
+            if (needsRemove)
+            {
+                var toRemove = DisposableList<PlayerID>.Create(16);
+                for (var i = 0; i < currentPlayers.Count; i++)
+                {
+                    var current = currentPlayers[i];
+                    if (!predictionManager.IsObserver(current))
+                        toRemove.Add(current);
+                }
+                input.removePlayers = toRemove;
+            }
         }
 
         protected override void Simulate(PredictedPlayersInput input, ref PredictedPlayersState state, float delta)


### PR DESCRIPTION
In PredictedPlayers.GetFinalInput method DisposableList<PlayerID>.Create(16) was being called unconditionally twice every tick for both toAdd and toRemove lists, regardless of whether any players actually joined or left the scene. Under heavy server load, this constant allocation triggers the Garbage Collector frequently, causing CPU spikes and stuttering (in my profiling, it contributed to GC spikes of up to 100+ ms over time).

With these changes the method now iterates through observers and currentPlayers first to check if any modifications are actually needed (needsAdd / needsRemove). The DisposableList allocations only occur if a player state change is detected.

I have tested this heavily on a headless Linux server build, and the memory/CPU footprint is now significanly stable. Hope this helps the project!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized player management operations to reduce unnecessary processing overhead and memory usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->