### PR TITLE
Emit event when PredictionManager instance added

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -32,7 +32,7 @@ namespace PurrNet.Prediction
 
         static readonly Dictionary<int, PredictionManager> _instances = new ();
 
-        static event Action<int, PredictionManager> OnInstanceAdded;
+        public static event Action<int, PredictionManager> OnInstanceAdded;
 
         [SerializeField] private PredictionPhysicsProvider _physicsProvider;
         [SerializeField] private UpdateViewMode _updateViewMode = UpdateViewMode.Update;
@@ -104,7 +104,7 @@ namespace PurrNet.Prediction
         private void Awake()
         {
             _instances[gameObject.scene.handle] = this;
-            OnInstanceAdded.Invoke(gameObject.scene.handle, this);
+            OnInstanceAdded?.Invoke(gameObject.scene.handle, this);
             _sessionSeed = (uint)UnityEngine.Random.Range(int.MinValue, int.MaxValue);
 
 #if UNITY_PHYSICS_2D

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -32,6 +32,8 @@ namespace PurrNet.Prediction
 
         static readonly Dictionary<int, PredictionManager> _instances = new ();
 
+        static event Action<int, PredictionManager> OnInstanceAdded;
+
         [SerializeField] private PredictionPhysicsProvider _physicsProvider;
         [SerializeField] private UpdateViewMode _updateViewMode = UpdateViewMode.Update;
         [SerializeField, PurrLock] private BuiltInSystems _builtInSystems =
@@ -102,6 +104,7 @@ namespace PurrNet.Prediction
         private void Awake()
         {
             _instances[gameObject.scene.handle] = this;
+            OnInstanceAdded.Invoke(gameObject.scene.handle, this);
             _sessionSeed = (uint)UnityEngine.Random.Range(int.MinValue, int.MaxValue);
 
 #if UNITY_PHYSICS_2D


### PR DESCRIPTION
Low impact. Simply alerts on addition of a new PredictionManager instance.

In my case, this is helpful for a DDOL manager class that must register a PredictedIdentity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new instance initialization event that notifies when prediction managers are created, enabling external systems to react to instance creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->