### PR TITLE
fix: prevent DeterministicIdentity tick desync after reconnect

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -307,6 +307,7 @@ namespace PurrNet.Prediction
             _clientFrames.Clear();
             localTick = 1;
             _lastVerifiedTick = 1;
+            _playedFirst = false;
             localTickInContext = 1;
             _deltas.Clear();
         }
@@ -503,6 +504,9 @@ namespace PurrNet.Prediction
         {
             isSimulating = true;
             _sessionSeed = randomSeed;
+
+            _lastVerifiedTick = 1;
+            _playedFirst = false;
 
             tickDelta = delta;
             this.tickRate = tickRate;


### PR DESCRIPTION
## Summary

Fixes a prediction tick desync that occurred after a client disconnected and reconnected **in scenes containing objects with `DeterministicIdentity`**.

After reconnecting, deterministic validation could report an off-by-one mismatch, for example the server state being at tick `462` while the client had already advanced to tick `463`. This caused deterministic objects (e.g., rotating obstacles) to be simulated one tick ahead locally, leading to divergence in collision/knockback prediction and visible correction jitter.

## Visual Evidence

The issue can be observed in the following video:

<img width="415" height="224" alt="PredictionManager" src="https://github.com/user-attachments/assets/73a87b30-3e21-44e4-b4c0-7cc762ff86d4" />

https://github.com/user-attachments/assets/d0ff73d0-4af0-41c2-9dbe-6cf267793341

## Root Cause

`PredictionManager` resets several session-related fields during reconnect/full-state sync, but `_playedFirst` could retain its value from the previous connection.

Because `_playedFirst` remained `true`, the first rollback after reconnect could incorrectly follow the “already played first frame” path, triggering an extra simulation step before the first authoritative state was fully aligned.

## Fix

Reset `_playedFirst` when receiving a new full prediction state, ensuring reconnect follows the same first-frame initialization flow as a fresh connection.

Also reset `_lastVerifiedTick` to `1` at the same point, keeping the verified tick baseline aligned with the full-state snapshot that is read and saved at tick `1`.

## Validation

Tested reconnect flow in scenes with `DeterministicIdentity` objects and deterministic obstacle validation enabled. The previous `State mismatch` (off-by-one tick) no longer occurs, and collision/knockback jitter after reconnect has been resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed prediction state synchronization to properly reset during full cleanup and state synchronization operations, ensuring correct first-frame handling and consistent rollback/replay logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->