### PR TITLE
feat: show predicted modules in PredictedIdentity editor

### DIFF
--- a/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
@@ -89,12 +89,50 @@ namespace PurrNet.Prediction.Editor
                 }
                 GUILayout.EndHorizontal();
 
+                DrawPredictedModules(predictedIdentity);
+
                 if (predictedIdentity.GetType().GetCustomAttributes(typeof(PredictionUnsafeAttribute), true).Length > 0)
                 {
                     EditorGUILayout.HelpBox("This identity is marked as PredictionUnsafe, which means use at your own risk.\n" +
                                             "It may not behave as expected or works against prediction.",
                         MessageType.Warning);
                 }
+            }
+        }
+
+        private void DrawPredictedModules(PredictedIdentity predictedIdentity)
+        {
+            var modules = predictedIdentity.Modules;
+            if (modules == null || modules.Count == 0)
+                return;
+
+            bool drewAny = false;
+
+            for (int i = 0; i < modules.Count; i++)
+            {
+                var module = modules[i];
+                if (module == null)
+                    continue;
+
+                var content = module.ToString();
+                var moduleName = module.GetType().Name;
+                if (string.IsNullOrEmpty(content) || string.IsNullOrEmpty(moduleName))
+                    continue;
+
+                if (!drewAny)
+                {
+                    GUILayout.Space(10);
+                    GUILayout.Label("Predicted Modules", EditorStyles.boldLabel);
+                    drewAny = true;
+                }
+
+                EditorGUILayout.BeginVertical("box");
+
+                var moduleDisplayName = $"{moduleName} [#{module.moduleIndex}]";
+                EditorGUILayout.LabelField(moduleDisplayName, EditorStyles.boldLabel);
+                GUILayout.Box(content, _box, GUILayout.ExpandWidth(true));
+
+                EditorGUILayout.EndVertical();
             }
         }
     }

--- a/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedIdentityEditor.cs
@@ -15,6 +15,7 @@ namespace PurrNet.Prediction.Editor
 #endif
     {
         static GUIStyle _box;
+        bool _showPredictedModules = false;
 
         public override VisualElement CreateInspectorGUI()
         {
@@ -106,7 +107,14 @@ namespace PurrNet.Prediction.Editor
             if (modules == null || modules.Count == 0)
                 return;
 
-            bool drewAny = false;
+            GUILayout.Space(5);
+            _showPredictedModules = EditorGUILayout.Foldout(
+                _showPredictedModules,
+                $"Predicted Modules ({modules.Count})",
+                true);
+
+            if (!_showPredictedModules)
+                return;
 
             for (int i = 0; i < modules.Count; i++)
             {
@@ -118,13 +126,6 @@ namespace PurrNet.Prediction.Editor
                 var moduleName = module.GetType().Name;
                 if (string.IsNullOrEmpty(content) || string.IsNullOrEmpty(moduleName))
                     continue;
-
-                if (!drewAny)
-                {
-                    GUILayout.Space(10);
-                    GUILayout.Label("Predicted Modules", EditorStyles.boldLabel);
-                    drewAny = true;
-                }
 
                 EditorGUILayout.BeginVertical("box");
 

--- a/Assets/PurrDiction/Runtime/AssemblyInfo.cs
+++ b/Assets/PurrDiction/Runtime/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PurrDiction.Editor")]

--- a/Assets/PurrDiction/Runtime/AssemblyInfo.cs.meta
+++ b/Assets/PurrDiction/Runtime/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ff3324438d83c0943b88ec52b7f7bfdd

--- a/Assets/PurrDiction/Runtime/Core/Modules/TimerModule.cs
+++ b/Assets/PurrDiction/Runtime/Core/Modules/TimerModule.cs
@@ -134,5 +134,10 @@ namespace PurrNet.Prediction
         {
             timer = null;
         }
+
+        public override string ToString()
+        {
+            return $"Timer={(timer.HasValue ? timer.Value.ToString("F2") : "null")}";
+        }
     }
 }

--- a/Assets/PurrDiction/Runtime/Core/PredictedIdentity.Module.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedIdentity.Module.cs
@@ -7,6 +7,7 @@ namespace PurrNet.Prediction
     public abstract partial class PredictedIdentity
     {
         private readonly List<PredictedModule> _modules = new();
+        internal IReadOnlyList<PredictedModule> Modules => _modules;
 
         protected void ModuleSetup(NetworkManager manager, PredictionManager world, PredictedComponentID id, PlayerID? owner)
         {

--- a/Assets/PurrDiction/Runtime/Core/PredictedModuleState.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedModuleState.cs
@@ -32,6 +32,11 @@ namespace PurrNet.Prediction
         protected ModuleDeltaKey<PredictedIdentityState> predictionKey => new ModuleDeltaKey<PredictedIdentityState>(identity.id, moduleIndex);
         protected ModuleDeltaKey<TState> stateKey => new ModuleDeltaKey<TState>(identity.id, moduleIndex);
 
+        public override string ToString()
+        {
+            return $"State:\n{fullPredictedState.state}";
+        }
+
         internal override void OnCoreInitialize()
         {
             var tickRate = predictionManager.tickRate;


### PR DESCRIPTION
PredictedIdentityEditor script now shows all the PredictedModules and their states which have been registered for that PredictedIdentity, runtime only.

<img width="720" height="477" alt="image" src="https://github.com/user-attachments/assets/c33ad078-1e29-49ea-83ca-1a456a775965" />

<img width="685" height="1018" alt="image" src="https://github.com/user-attachments/assets/c5fd9347-79c7-4f53-a370-916c125a822c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Predicted Modules" section to the editor inspector, displaying active modules with their type names and state information for easier debugging and inspection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->