### PR TITLE
Assert isController for bots on server

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
@@ -123,9 +123,9 @@ namespace PurrNet.Prediction
             {
                 if (!predictionManager)
                     return false;
-                if (owner.HasValue && predictionManager.isSpawned)
-                    return owner == predictionManager.localPlayer;
-                return predictionManager.cachedIsServer;
+
+                var player = predictionManager.isSpawned ? predictionManager.localPlayer ?? default : default;
+                return IsOwner(player, predictionManager.cachedIsServer);
             }
         }
 


### PR DESCRIPTION
See https://discord.com/channels/1288872904272121957/1498480697663426570.

The [docs](https://purrnet.dev/docs/client-side-prediction/views-and-interpolation) state:
isController: True for the owner on clients; on server, also true for bots/AI.

This does not seem to be true in practice. Rather, the PredictedIdentity is comparing its owner to the local player.

From [PredictedIdentity.cs](https://github.com/PurrNet/PurrDiction/blob/0fa898f8c3567f0a94f5148e9c6790f497f505e9/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs#L120):

```csharp
public bool isController
{
    get
    {
        if (!predictionManager)
            return false;
        if (owner.HasValue && predictionManager.isSpawned)
            return owner == predictionManager.localPlayer;
        return predictionManager.cachedIsServer;
    }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal control flow logic for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->