### PR TITLE
Query players by raw ID

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedPlayers.cs
@@ -25,6 +25,27 @@ namespace PurrNet.Prediction
             _scenePlayersModule = predictionManager.networkManager.scenePlayersModule;
         }
 
+        public PlayerID? GetPlayer(ulong? id) => TryGetPlayer(id, out var player) ? player : null;
+
+        public bool TryGetPlayer(ulong? id, out PlayerID player)
+        {
+            player = default;
+
+            if (!id.HasValue) return false;
+            var rawId = id.Value;
+
+            foreach (var p in players)
+            {
+                if (p.id == rawId)
+                {
+                    player = p;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         protected override PredictedPlayersState GetInitialState()
         {
             return new PredictedPlayersState


### PR DESCRIPTION
#36 (merged in `d0220c54090e30b61363eeb4825442f307565bc8`) was silently dropped (in `006a6ccbcbad8b0dcd8b409452e7fad5355b6b71`). See [discussion](https://discord.com/channels/1288872904272121957/1342103548384509982/1499459571205279834).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new methods for retrieving player information by identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->