### PR TITLE
Expose default state index

### DIFF
--- a/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
@@ -36,6 +36,7 @@ namespace PurrNet.Prediction.Editor
     public class PredictedStateMachineEditor : UnityEditor.Editor
     {
         private PredictedStateMachine _stateMachine;
+        private SerializedProperty _defaultStateIndexProperty;
         private SerializedProperty _statesProperty;
         
         private class StateCache
@@ -53,6 +54,7 @@ namespace PurrNet.Prediction.Editor
         private void OnEnable()
         {
             _stateMachine = target as PredictedStateMachine;
+            _defaultStateIndexProperty = serializedObject.FindProperty("_defaultStateIndex");
             _statesProperty = serializedObject.FindProperty("_wrappedStates");
             EditorApplication.update += OnEditorUpdate;
         }
@@ -175,6 +177,7 @@ namespace PurrNet.Prediction.Editor
             if (Application.isPlaying)
                 EditorGUI.BeginDisabledGroup(true);
 
+            EditorGUILayout.PropertyField(_defaultStateIndexProperty, new GUIContent("Default State Index"));
             EditorGUILayout.PropertyField(_statesProperty, new GUIContent("States"), true);
 
             if (Application.isPlaying)

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -169,7 +169,13 @@ namespace PurrNet.Prediction.StateMachine
 
         public void SetState(IPredictedStateNodeBase state)
         {
-            var index = _states.IndexOf(state);
+            if (state == null)
+            {
+                SetState(-1);
+                return;
+            }
+
+            var index = _states?.IndexOf(state) ?? -1;
             if (index == -1)
             {
                 PurrLogger.LogError($"Can't switch state. Either state ({state}) is invalid, or doesn't exist in states list!", this);

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -19,7 +19,7 @@ namespace PurrNet.Prediction.StateMachine
         {
             get
             {
-                if(currentState.stateIndex < 0 || currentState.stateIndex >= _states.Count)
+                if (_states == null || currentState.stateIndex < 0 || currentState.stateIndex >= _states.Count)
                     return null;
 
                 return _states[currentState.stateIndex];

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -169,13 +169,7 @@ namespace PurrNet.Prediction.StateMachine
 
         public void SetState(IPredictedStateNodeBase state)
         {
-            if (state == null)
-            {
-                SetState(-1);
-                return;
-            }
-
-            var index = _states?.IndexOf(state) ?? -1;
+            var index = _states.IndexOf(state);
             if (index == -1)
             {
                 PurrLogger.LogError($"Can't switch state. Either state ({state}) is invalid, or doesn't exist in states list!", this);

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -8,6 +8,8 @@ namespace PurrNet.Prediction.StateMachine
     [AddComponentMenu("PurrDiction/Predicted State machine")]
     public class PredictedStateMachine : PredictedIdentity<PredictedStateMachine.SMState>
     {
+        [SerializeField, Min(-1)] private int _defaultStateIndex = 0;
+
         [SerializeField] private List<SerializableInterface<IPredictedStateNodeBase>> _wrappedStates =
             new List<SerializableInterface<IPredictedStateNodeBase>>();
         private List<IPredictedStateNodeBase> _states;
@@ -34,7 +36,8 @@ namespace PurrNet.Prediction.StateMachine
         private void Awake()
         {
             _states = _wrappedStates.Select(wrapped => wrapped.Value).ToList();
-            _currentStateNode = _states.FirstOrDefault();
+            var defaultStateIndex = GetValidDefaultStateIndex();
+            _currentStateNode = defaultStateIndex > -1 ? _states[defaultStateIndex] : null;
 
             for (var i = 0; i < _states.Count; i++)
             {
@@ -43,6 +46,25 @@ namespace PurrNet.Prediction.StateMachine
                 var state = _states[i];
                 state.Setup(this);
             }
+        }
+
+        private int GetValidDefaultStateIndex()
+        {
+            if (_defaultStateIndex < 0)
+                return -1;
+
+            if (_states != null)
+            {
+                if (_defaultStateIndex >= _states.Count)
+                    return -1;
+
+                return _states[_defaultStateIndex] != null ? _defaultStateIndex : -1;
+            }
+
+            if (_defaultStateIndex >= _wrappedStates.Count)
+                return -1;
+
+            return _wrappedStates[_defaultStateIndex]?.Value != null ? _defaultStateIndex : -1;
         }
 
         private uint _prevViewTransition;
@@ -113,9 +135,10 @@ namespace PurrNet.Prediction.StateMachine
 
         protected override SMState GetInitialState()
         {
+            var defaultStateIndex = GetValidDefaultStateIndex();
             var state = new SMState()
             {
-                wantedState = 0,
+                wantedState = defaultStateIndex,
                 stateIndex = -1,
                 lastEnteredStateIndex = -1
             };


### PR DESCRIPTION
Allows setting the default state index via inspector. For my application, this allows starting in a no-op state without creating a placeholder PredictedStateNode by setting Default State Index to -1.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable default/initial state for state machines, exposed in the editor as a "Default State Index" field for easy setup.

* **Improvements**
  * Validation ensures the configured default state is verified and only applied if valid during initialization.
  * Runtime guards prevent errors when state collections are unavailable at startup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PurrNet/PurrDiction/pull/51)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->