### PR TITLE
Emit event on state enter

### DIFF
--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -12,7 +12,8 @@ namespace PurrNet.Prediction.StateMachine
             new List<SerializableInterface<IPredictedStateNodeBase>>();
         private List<IPredictedStateNodeBase> _states;
         public IReadOnlyList<IPredictedStateNodeBase> states => _states;
-        public event System.Action<int, IPredictedStateNodeBase> onStateEntered;
+        public event StateChangedDelegate onStateChanged;
+        public delegate void StateChangedDelegate(IPredictedStateNodeBase previousState, IPredictedStateNodeBase newState);
 
         public IPredictedStateNodeBase currentStateNode
         {
@@ -85,21 +86,28 @@ namespace PurrNet.Prediction.StateMachine
                 state.wantedState = -1;
 
                 if (state.stateIndex > -1)
-                    _states[state.stateIndex].Exit();
+                {
+                    var previousState = _states[state.stateIndex];
+                    previousState.Exit();
+                }
 
+                var oldState = state.stateIndex > -1 ? _states[state.stateIndex] : null;
                 state.stateIndex = index;
-                _states[state.stateIndex].Enter();
-                onStateEntered?.Invoke(state.stateIndex, _states[state.stateIndex]);
+                var newState = _states[state.stateIndex];
+                newState.Enter();
+                onStateChanged?.Invoke(oldState, newState);
                 state.lastEnteredStateIndex = state.stateIndex;
                 state.transition++;
             }
             else if (state.stateIndex > -1 && state.stateIndex != state.lastEnteredStateIndex)
             {
-                _states[state.stateIndex].Enter();
-                onStateEntered?.Invoke(state.stateIndex, _states[state.stateIndex]);
+                var newState = _states[state.stateIndex];
+                var oldState = ReferenceEquals(_currentStateNode, newState) ? null : _currentStateNode;
+                newState.Enter();
+                onStateChanged?.Invoke(oldState, newState);
                 state.lastEnteredStateIndex = state.stateIndex;
                 _previousStateNode = null;
-                _currentStateNode = _states[state.stateIndex];
+                _currentStateNode = newState;
                 _nextStateNode = _states[(state.stateIndex + 1) % _states.Count];
             }
 
@@ -157,6 +165,11 @@ namespace PurrNet.Prediction.StateMachine
             }
 
             SetState(index);
+        }
+
+        public int GetStateId(IPredictedStateNodeBase state)
+        {
+            return _states.IndexOf(state);
         }
 
         private void SetWantedStateIndex(int index)

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using PurrNet.Logging;
 using UnityEngine;
 
@@ -75,6 +76,7 @@ namespace PurrNet.Prediction.StateMachine
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override void Simulate(ref SMState state, float delta)
         {
             base.Simulate(ref state, delta);

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -12,6 +12,7 @@ namespace PurrNet.Prediction.StateMachine
             new List<SerializableInterface<IPredictedStateNodeBase>>();
         private List<IPredictedStateNodeBase> _states;
         public IReadOnlyList<IPredictedStateNodeBase> states => _states;
+        public event System.Action<int, IPredictedStateNodeBase> onStateEntered;
 
         public IPredictedStateNodeBase currentStateNode
         {
@@ -88,12 +89,14 @@ namespace PurrNet.Prediction.StateMachine
 
                 state.stateIndex = index;
                 _states[state.stateIndex].Enter();
+                onStateEntered?.Invoke(state.stateIndex, _states[state.stateIndex]);
                 state.lastEnteredStateIndex = state.stateIndex;
                 state.transition++;
             }
             else if (state.stateIndex > -1 && state.stateIndex != state.lastEnteredStateIndex)
             {
                 _states[state.stateIndex].Enter();
+                onStateEntered?.Invoke(state.stateIndex, _states[state.stateIndex]);
                 state.lastEnteredStateIndex = state.stateIndex;
                 _previousStateNode = null;
                 _currentStateNode = _states[state.stateIndex];

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateNode.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateNode.cs
@@ -2,6 +2,7 @@ namespace PurrNet.Prediction.StateMachine
 {
     public interface IPredictedStateNodeBase
     {
+        int stateId { get; }
         void Setup(PredictedStateMachine stateMachine);
         void Enter();
         void ViewEnter(bool isVerified);
@@ -14,6 +15,7 @@ namespace PurrNet.Prediction.StateMachine
         where T : struct, IPredictedData<T>
     {
         protected PredictedStateMachine machine { get; private set; }
+        public int stateId => machine ? machine.GetStateId(this) : -1;
 
         public void Setup(PredictedStateMachine stateMachine)
         {
@@ -48,6 +50,8 @@ namespace PurrNet.Prediction.StateMachine
         where TInput : struct, IPredictedData
     {
         protected PredictedStateMachine machine { get; private set; }
+        public int stateId => machine ? machine.GetStateId(this) : -1;
+
         public void Setup(PredictedStateMachine stateMachine)
         {
             machine = stateMachine;

--- a/Assets/PurrDictionTests/SampleSceneUnity.unity
+++ b/Assets/PurrDictionTests/SampleSceneUnity.unity
@@ -732,6 +732,7 @@ MonoBehaviour:
   - {fileID: 367461690}
   - {fileID: 587401258}
   - {fileID: 946599082}
+  _waitForSpawnCall: 0
 --- !u!4 &457991333
 Transform:
   m_ObjectHideFlags: 0
@@ -885,6 +886,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 21d13622c5da2b14384a1c1abe0ea087, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _predictedMachine: {fileID: 1871079014}
 --- !u!4 &1179252127
 Transform:
   m_ObjectHideFlags: 0
@@ -1012,7 +1014,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _stopPlayingOnDisconnect: 0
   _startServerFlags: 9
-  _startClientFlags: 6
+  _startClientFlags: 7
   _cookieScope: 1
   _dontDestroyOnLoad: 1
   _transport: {fileID: 1793795283}

--- a/Assets/PurrDictionTests/TestState.cs
+++ b/Assets/PurrDictionTests/TestState.cs
@@ -7,17 +7,27 @@ namespace PurrNet.Prediction.Tests
 {
     public class TestState : PredictedStateNode<TestState.StateData>
     {
+        [SerializeField] private PredictedStateMachine _predictedMachine;
         public static List<TestState> Instances = new();
 
         private void Awake()
         {
             Instances.Add(this);
+            _predictedMachine.onStateChanged += OnStateChanged;
         }
 
         protected override void OnDestroy()
         {
             base.OnDestroy();
             Instances.Remove(this);
+            _predictedMachine.onStateChanged -= OnStateChanged;
+        }
+
+        private void OnStateChanged(IPredictedStateNodeBase previousState, IPredictedStateNodeBase newState)
+        {
+            string prev = previousState == null ? "null" : previousState.GetType().Name;
+            string next = newState == null ? "null" : newState.GetType().Name;
+            Debug.Log($"On State Changed: {prev}, {next}");
         }
 
         public override void ViewEnter(bool isVerified)


### PR DESCRIPTION


<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/52"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * State machine now broadcasts state change events with previous and new state details, enabling external systems to observe transitions.
  * States are assigned unique identifiers for easier tracking and reference throughout your application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PurrNet/PurrDiction/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->