### PR TITLE
Virtualize PredictedStateMachine next/prev

### DIFF
--- a/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
@@ -32,7 +32,7 @@ namespace PurrNet.Prediction.Editor
         }
     }
     
-    [CustomEditor(typeof(PredictedStateMachine), true)]
+    [CustomEditor(typeof(PredictedStateMachine))]
     public class PredictedStateMachineEditor : UnityEditor.Editor
     {
         private PredictedStateMachine _stateMachine;

--- a/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
@@ -32,9 +32,16 @@ namespace PurrNet.Prediction.Editor
         }
     }
     
-    [CustomEditor(typeof(PredictedStateMachine))]
+    [CustomEditor(typeof(PredictedStateMachine), true)]
     public class PredictedStateMachineEditor : UnityEditor.Editor
     {
+        private static readonly string[] ExcludedProperties =
+        {
+            "m_Script",
+            "_defaultStateIndex",
+            "_wrappedStates"
+        };
+
         private PredictedStateMachine _stateMachine;
         private SerializedProperty _statesProperty;
         
@@ -176,6 +183,7 @@ namespace PurrNet.Prediction.Editor
                 EditorGUI.BeginDisabledGroup(true);
 
             EditorGUILayout.PropertyField(_statesProperty, new GUIContent("States"), true);
+            DrawPropertiesExcluding(serializedObject, ExcludedProperties);
 
             if (Application.isPlaying)
                 EditorGUI.EndDisabledGroup();

--- a/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
+++ b/Assets/PurrDiction/Editor/PredictedStateMachineEditor.cs
@@ -32,7 +32,7 @@ namespace PurrNet.Prediction.Editor
         }
     }
     
-    [CustomEditor(typeof(PredictedStateMachine))]
+    [CustomEditor(typeof(PredictedStateMachine), true)]
     public class PredictedStateMachineEditor : UnityEditor.Editor
     {
         private PredictedStateMachine _stateMachine;

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -31,7 +31,7 @@ namespace PurrNet.Prediction.StateMachine
         private int _previousViewStateIndex = -1;
         private int _previousVerifiedViewStateIndex = -1;
 
-        private void Awake()
+        protected virtual void Awake()
         {
             _states = _wrappedStates.Select(wrapped => wrapped.Value).ToList();
             _currentStateNode = _states.FirstOrDefault();

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -123,14 +123,14 @@ namespace PurrNet.Prediction.StateMachine
             return state;
         }
 
-        public void Next()
+        public virtual void Next()
         {
             if (_states.Count == 0) return;
             var nextIndex = (currentState.stateIndex + 1) % _states.Count;
             SetState(nextIndex);
         }
 
-        public void Previous()
+        public virtual void Previous()
         {
             if (_states.Count == 0) return;
             var previousIndex = (currentState.stateIndex - 1 + _states.Count) % _states.Count;

--- a/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
+++ b/Assets/PurrDiction/Runtime/StateMachine/PredictedStateMachine.cs
@@ -31,7 +31,7 @@ namespace PurrNet.Prediction.StateMachine
         private int _previousViewStateIndex = -1;
         private int _previousVerifiedViewStateIndex = -1;
 
-        protected virtual void Awake()
+        private void Awake()
         {
             _states = _wrappedStates.Select(wrapped => wrapped.Value).ToList();
             _currentStateNode = _states.FirstOrDefault();


### PR DESCRIPTION
Allows PredictedStateMachine subclasses to override `Next()` and `Previous()` methods. In my case, my state machine is deferring state selection to another script.

Edit: ~~Also enabled inheritance for PredictedStateMachineEditor.~~ Edit2: ~~That was a bad idea; serialized fields of the subclass are not presented in the inspector.~~ Edit3: Correctly implemented by drawing properties besides those already drawn by the custom editor.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved state machine extensibility to support custom implementations.
  * Internal navigation logic made more adaptable; no changes to existing behavior or user workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PurrNet/PurrDiction/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->