### PR TITLE
Fire events before & after physics pass

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -859,11 +859,17 @@ namespace PurrNet.Prediction
 
         /// <summary>
         /// Invoked immediately before PurrDiction simulates its configured physics scenes.
+        /// This is also fired during resimulation after a rollback, before each replayed physics pass.
+        /// This occurs after <see cref="PredictedIdentity.Simulate()"/> and before
+        /// <see cref="PredictedIdentity.LateSimulate()"/>.
         /// </summary>
         public event Action onBeforePhysicsPass;
 
         /// <summary>
         /// Invoked immediately after PurrDiction simulates its configured physics scenes.
+        /// This is also fired during resimulation after a rollback, after each replayed physics pass.
+        /// This occurs after <see cref="PredictedIdentity.Simulate()"/> and before
+        /// <see cref="PredictedIdentity.LateSimulate()"/>.
         /// </summary>
         public event Action onAfterPhysicsPass;
 

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -857,32 +857,50 @@ namespace PurrNet.Prediction
             get; private set;
         }
 
+        /// <summary>
+        /// Invoked immediately before PurrDiction simulates its configured physics scenes.
+        /// </summary>
+        public event Action onBeforePhysicsPass;
+
+        /// <summary>
+        /// Invoked immediately after PurrDiction simulates its configured physics scenes.
+        /// </summary>
+        public event Action onAfterPhysicsPass;
+
         private void DoPhysicsPass()
         {
-            isInPhysicsPass = true;
             // ReSharper disable once NotAccessedVariable
             var delta = tickDelta;
             if (time)
                 delta *= time.timeScale;
 
-#if UNITY_PHYSICS_2D
-            if ((_physicsProvider & PredictionPhysicsProvider.UnityPhysics2D) != 0)
+            onBeforePhysicsPass?.Invoke();
+
+            isInPhysicsPass = true;
+            try
             {
-                var physicsScene = gameObject.scene.GetPhysicsScene2D();
-                if (physicsScene.IsValid())
-                    physicsScene.Simulate(delta);
-            }
+#if UNITY_PHYSICS_2D
+                if ((_physicsProvider & PredictionPhysicsProvider.UnityPhysics2D) != 0)
+                {
+                    var physicsScene = gameObject.scene.GetPhysicsScene2D();
+                    if (physicsScene.IsValid())
+                        physicsScene.Simulate(delta);
+                }
 #endif
 #if UNITY_PHYSICS_3D
-            if ((_physicsProvider & PredictionPhysicsProvider.UnityPhysics3D) != 0)
-            {
-                var physicsScene = gameObject.scene.GetPhysicsScene();
-                if (physicsScene.IsValid())
-                    physicsScene.Simulate(delta);
-            }
+                if ((_physicsProvider & PredictionPhysicsProvider.UnityPhysics3D) != 0)
+                {
+                    var physicsScene = gameObject.scene.GetPhysicsScene();
+                    if (physicsScene.IsValid())
+                        physicsScene.Simulate(delta);
+                }
 #endif
-
-            isInPhysicsPass = false;
+            }
+            finally
+            {
+                isInPhysicsPass = false;
+                onAfterPhysicsPass?.Invoke();
+            }
         }
 
         struct FrameDelta : IDisposable

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -874,7 +874,14 @@ namespace PurrNet.Prediction
             if (time)
                 delta *= time.timeScale;
 
-            onBeforePhysicsPass?.Invoke();
+            try
+            {
+                onBeforePhysicsPass?.Invoke();
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
 
             isInPhysicsPass = true;
             try
@@ -899,7 +906,15 @@ namespace PurrNet.Prediction
             finally
             {
                 isInPhysicsPass = false;
-                onAfterPhysicsPass?.Invoke();
+
+                try
+                {
+                    onAfterPhysicsPass?.Invoke();
+                }
+                catch (Exception e)
+                {
+                    Debug.LogException(e);
+                }
             }
         }
 


### PR DESCRIPTION
Two new events: `onBeforePhysicsPass` and `onAfterPhysicsPass`. This allows for more precise timing. It is a departure from PurrNet's `LateLateUpdate` pattern but is, in my opinion, a little cleaner and more descriptive. Opening this as a draft as I'm interested in feedback and/or other approaches.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783322765&installation_id=129033668&pr_number=54&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F54&signature=e63b2dc225f67dd7bfb2682b2828eaeef37ffaf5ca26ee17e39b75105cab046c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added lifecycle hooks that fire immediately before and after each physics update, enabling custom actions to run in sync with physics simulation.
* **Bug Fixes**
  * Ensures physics-run state is reliably cleared even if errors occur.
  * Handler exceptions are caught and logged so they do not interrupt the physics pass.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->