### PR TITLE
PredictedModule GetInitialState and Destroyed

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedIdentity.Module.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedIdentity.Module.cs
@@ -316,6 +316,12 @@ namespace PurrNet.Prediction
             _moduleHistory?.Clear();
         }
 
+        private void TriggerModuleDestroyedEvents()
+        {
+            for (int i = 0; i < _modules.Count; i++)
+                _modules[i].TriggerDestroyedEvent();
+        }
+
         private void TearDownAllDynamic()
         {
             if (_staticModuleCount < 0) return;

--- a/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
@@ -92,6 +92,7 @@ namespace PurrNet.Prediction
         internal void TriggerDestroyedEvent()
         {
             Destroyed();
+            TriggerModuleDestroyedEvents();
         }
 
         public bool isServer { get; private set; }
@@ -126,6 +127,7 @@ namespace PurrNet.Prediction
         protected virtual void OnDestroy()
         {
             Destroyed();
+            TriggerModuleDestroyedEvents();
             TearDownAllModules();
 
             if (predictionManager)

--- a/Assets/PurrDiction/Runtime/Core/PredictedModule.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedModule.cs
@@ -180,6 +180,11 @@ namespace PurrNet.Prediction
             onDisposed?.Invoke();
         }
 
+        internal void TriggerDestroyedEvent()
+        {
+            Destroyed();
+        }
+
         /// <summary>
         /// Invoked when the module is removed from its identity.
         /// Use this to drop any external references to the module.
@@ -191,5 +196,11 @@ namespace PurrNet.Prediction
         /// Override to release any owned resources.
         /// </summary>
         protected virtual void OnDisposed() { }
+
+        /// <summary>
+        /// Invoked when the owning identity is being despawned and cleaned up.
+        /// Allows for any necessary teardown or resource release to be handled.
+        /// </summary>
+        protected virtual void Destroyed() { }
     }
 }

--- a/Assets/PurrDiction/Runtime/Core/PredictedModuleState.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedModuleState.cs
@@ -37,6 +37,12 @@ namespace PurrNet.Prediction
             return $"State:\n{fullPredictedState.state}";
         }
 
+        private void ResetStateToInitialState()
+        {
+            fullPredictedState.prediction.wasOnSimulationStartCalled = false;
+            fullPredictedState.state = GetInitialState();
+        }
+
         internal override void OnCoreInitialize()
         {
             var tickRate = predictionManager.tickRate;
@@ -50,6 +56,16 @@ namespace PurrNet.Prediction
                 fullPredictedState.DeepCopy(),
                 bufferSize
             );
+        }
+
+        protected override void Setup(PredictedIdentity parent, PredictionManager world)
+        {
+            base.Setup(parent, world);
+            ResetStateToInitialState();
+            _history?.Clear();
+            _viewState?.Dispose();
+            _viewState = null;
+            _interpolatedState?.Teleport(fullPredictedState.DeepCopy());
         }
 
         protected sealed override void UpdateView(float delta)
@@ -134,6 +150,13 @@ namespace PurrNet.Prediction
         /// Called exactly once before the very first simulation tick executes.
         /// </summary>
         protected virtual void SimulationStart() { }
+
+        /// <summary>
+        /// Called when the module is first created.
+        /// Future updates will come only through Simulate.
+        /// </summary>
+        /// <returns>The initial state of the module.</returns>
+        protected virtual TState GetInitialState() => default;
 
         /// <summary>
         /// Executes the simulation logic for this module.


### PR DESCRIPTION
Lifecycle events mirror PredictedIdentity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783812806&installation_id=129033668&pr_number=55&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F55&signature=40808331c7453fbd9e7def42d7b3d308a9ff182ae1087fb86abdc2b3a206d16d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added module lifecycle hooks for cleanup and despawn handling
  * Introduced configurable initial state setup for module instances
  * Enhanced module event dispatch to ensure proper cleanup sequencing during destruction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->