### PR TITLE
fix: resolve AssemblyResolver ambiguity on Unity 6.7

### DIFF
--- a/Assets/PurrDiction/Codegen/PredictionProcessor.cs
+++ b/Assets/PurrDiction/Codegen/PredictionProcessor.cs
@@ -4,7 +4,6 @@ using System.IO;
 using JetBrains.Annotations;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
-using PurrNet.Codegen;
 using PurrNet.Pooling;
 using PurrNet.Prediction;
 using Unity.CompilationPipeline.Common.Diagnostics;
@@ -56,7 +55,8 @@ namespace Purrdiction.Codegen
 
                 using var peStream = new MemoryStream(compiledAssembly.InMemoryAssembly.PeData);
                 using var pdbStream = new MemoryStream(compiledAssembly.InMemoryAssembly.PdbData);
-                var resolver = new AssemblyResolver(compiledAssembly);
+                // fully qualified: conflicts with Unity.CompilationPipeline.Common.ILPostProcessing.AssemblyResolver (Unity 6.7+)
+                var resolver = new PurrNet.Codegen.AssemblyResolver(compiledAssembly);
 
                 var assemblyDefinition = AssemblyDefinition.ReadAssembly(peStream, new ReaderParameters
                 {
@@ -84,7 +84,7 @@ namespace Purrdiction.Codegen
 
                         FPProcessor.HandleType(module, type, messages);
 
-                        if (!PostProcessor.InheritsFrom(type, typeof(PredictedIdentity).FullName))
+                        if (!PurrNet.Codegen.PostProcessor.InheritsFrom(type, typeof(PredictedIdentity).FullName))
                             continue;
 
                         var methods = type.Methods;
@@ -160,8 +160,9 @@ namespace Purrdiction.Codegen
 
         private static void ProcessMethod(MethodDefinition method, ModuleDefinition module)
         {
-            var predictedIdentity = module.GetTypeDefinition<PredictedIdentity>();
-            var isSimulating = predictedIdentity.GetMethod("IsSimulating").Import(module);
+            var predictedIdentity = PurrNet.Codegen.ModuleExtensions.GetTypeDefinition(module, typeof(PredictedIdentity));
+            var isSimulatingMethod = PurrNet.Codegen.ModuleExtensions.GetMethod(predictedIdentity, "IsSimulating");
+            var isSimulating = PurrNet.Codegen.ModuleExtensions.Import(module, isSimulatingMethod);
 
             var instructions = method.Body.Instructions;
             var processor = method.Body.GetILProcessor();


### PR DESCRIPTION
Fix for the following error on Unity 6.7:

`Library\PackageCache\dev.purrnet.purrdiction@2cb56d16fb44\Codegen\PredictionProcessor.cs(59,36): error CS0104: 'AssemblyResolver' is an ambiguous reference between 'PurrNet.Codegen.AssemblyResolver' and 'Unity.CompilationPipeline.Common.ILPostProcessing.AssemblyResolver'`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790793171&installation_model_id=20441&pr_number=71&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F71&signature=0e866cc5b43f61b4fb0238a59a5c2dd0c5a2f85c215a58f4a05fad20c743870f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->