### PR TITLE
Update deleted identity cache for physics events

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -544,6 +544,7 @@ namespace PurrNet.Prediction
         }
 
         readonly Dictionary<PredictedComponentID, PredictedIdentity> _instanceMap = new ();
+        readonly Dictionary<PredictedComponentID, PredictedIdentity> _deletingInstanceMap = new ();
 
         public bool TryGetIdentity(PredictedComponentID id, out PredictedIdentity instance)
         {
@@ -553,6 +554,20 @@ namespace PurrNet.Prediction
         public PredictedIdentity GetIdentity(PredictedComponentID id)
         {
             return _instanceMap.GetValueOrDefault(id);
+        }
+
+        internal PredictedIdentity GetIdentityIncludingDeleting(PredictedComponentID id)
+        {
+            if (_instanceMap.TryGetValue(id, out var identity))
+                return identity;
+
+            return _deletingInstanceMap.GetValueOrDefault(id);
+        }
+
+        internal GameObject GetGameObjectIncludingDeleting(PredictedComponentID id)
+        {
+            var identity = GetIdentityIncludingDeleting(id);
+            return identity ? identity.gameObject : null;
         }
 
         private void RegisterInstance(PredictedIdentity system, PredictedObjectID objectId, uint componentId, PlayerID? owner, bool preserveState = false)
@@ -621,6 +636,9 @@ namespace PurrNet.Prediction
             if (_instanceMap.TryGetValue(predictedIdentity.id, out var mapped) &&
                 ReferenceEquals(mapped, predictedIdentity))
             {
+                if (isSimulating)
+                    _deletingInstanceMap[predictedIdentity.id] = predictedIdentity;
+
                 _instanceMap.Remove(predictedIdentity.id);
                 _recordDecodeQuarantine.Remove(predictedIdentity.id);
                 _recordFailureLogAt.Remove(predictedIdentity.id);
@@ -876,15 +894,7 @@ namespace PurrNet.Prediction
                 }
             }
 
-            try
-            {
-                for (var i = 0; i < _systemsCount; i++)
-                    _systems[i].RunPostSimulate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-            }
+            PostSimulateAll();
 
             RestoreSpeculativeRelayStates();
 
@@ -2925,15 +2935,7 @@ namespace PurrNet.Prediction
                 }
             }
 
-            try
-            {
-                for (var i = 0; i < _systemsCount; i++)
-                    _systems[i].RunPostSimulate();
-            }
-            catch (Exception e)
-            {
-                Debug.LogException(e);
-            }
+            PostSimulateAll();
 
             try
             {
@@ -3367,6 +3369,23 @@ namespace PurrNet.Prediction
             {
                 UnregisterInstance(instance, false, true);
                 UnityProxy.DestroyImmediateDirectly(instance);
+            }
+        }
+
+        private void PostSimulateAll()
+        {
+            try
+            {
+                for (var i = 0; i < _systemsCount; i++)
+                    _systems[i].RunPostSimulate();
+            }
+            catch (Exception e)
+            {
+                Debug.LogException(e);
+            }
+            finally
+            {
+                _deletingInstanceMap.Clear();
             }
         }
 

--- a/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted2DPhysics.cs
+++ b/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted2DPhysics.cs
@@ -120,7 +120,9 @@ namespace PurrNet.Prediction
         {
             if (ev.me.TryGetIdentity<PredictedRigidbody2D>(predictionManager, out var me))
             {
-                var otherGo = ev.other.GetGameObject(predictionManager);
+                var otherGo = ev.type == PhysicsEventType.Exit
+                    ? predictionManager.GetGameObjectIncludingDeleting(ev.other)
+                    : ev.other.GetGameObject(predictionManager);
                 if (!otherGo && ev.other.objectId.instanceId.value != 0)
                     return;
                 if (ev.isTrigger)

--- a/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted3DPhysics.cs
+++ b/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted3DPhysics.cs
@@ -58,7 +58,9 @@ namespace PurrNet.Prediction
 
             if (ev.me.TryGetIdentity<IPredictedPhysicsCallbacks>(predictionManager, out var me))
             {
-                var otherGo = ev.other.GetGameObject(predictionManager);
+                var otherGo = ev.type == PhysicsEventType.Exit
+                    ? predictionManager.GetGameObjectIncludingDeleting(ev.other)
+                    : ev.other.GetGameObject(predictionManager);
                 if (!otherGo && ev.other.objectId.instanceId.value != 0)
                     return;
                 if (ev.isTrigger)

--- a/Assets/PurrDictionTests/EditorTests/IdentityRegistrationTests.cs
+++ b/Assets/PurrDictionTests/EditorTests/IdentityRegistrationTests.cs
@@ -78,6 +78,37 @@ namespace PurrNet.Prediction.Tests.Editor
             }
         }
 
+        [Test]
+        public void UnregisteringLiveIdentityDuringSimulationKeepsDeletingLookupUntilPostSimulate()
+        {
+            var managerObject = new GameObject("Registration manager");
+            var identityObject = new GameObject("Deleting identity");
+            try
+            {
+                var id = new PredictedComponentID(new PredictedObjectID(905), 0);
+                var manager = CreateManager(managerObject);
+                SetField(manager, "<isSimulating>k__BackingField", true);
+
+                var identity = identityObject.AddComponent<OmittedStateIdentity>();
+                identity.AttachForTest(manager, id);
+                Register(manager, identity);
+
+                manager.UnregisterInstance(identity);
+
+                Assert.That(manager.GetIdentity(id), Is.Null);
+                Assert.That(manager.GetGameObjectIncludingDeleting(id), Is.SameAs(identityObject));
+
+                InvokePrivate(manager, "PostSimulateAll");
+
+                Assert.That(manager.GetGameObjectIncludingDeleting(id), Is.Null);
+            }
+            finally
+            {
+                Object.DestroyImmediate(identityObject);
+                Object.DestroyImmediate(managerObject);
+            }
+        }
+
         private static void Register(
             PredictionManager manager,
             PredictedIdentity identity)
@@ -115,6 +146,13 @@ namespace PurrNet.Prediction.Tests.Editor
             var field = typeof(PredictionManager).GetField(name, InstanceFields);
             Assert.That(field, Is.Not.Null, $"missing field {name}");
             field.SetValue(manager, value);
+        }
+
+        private static void InvokePrivate(PredictionManager manager, string name)
+        {
+            var method = typeof(PredictionManager).GetMethod(name, InstanceFields);
+            Assert.That(method, Is.Not.Null, $"missing method {name}");
+            method.Invoke(manager, null);
         }
     }
 }


### PR DESCRIPTION
See #56 and #57.

This is an updated and narrowed version of the above PRs. In short, this caches identities deleted from the hierarchy in order to use said identities in physics events.

A simple case where this is critical is when deleting an identity via `PredictedHierarchy.Delete()` e.g. a PredictedRigidbody2D, bodies touching this body should invoke `PredictedRigidbody2D.onCollisionExit()` containing the deleted identity.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791233831&installation_model_id=20441&pr_number=72&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F72&signature=124611963656caba2b62761f9d8a21d98e23021dd0bf1c4fc4765a1cd1814966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->