### PR TITLE
Include component ID in all physics events

### DIFF
--- a/Assets/PredictionTests/Scripts/Scenarios/BounceProbe.cs
+++ b/Assets/PredictionTests/Scripts/Scenarios/BounceProbe.cs
@@ -73,7 +73,7 @@ public class BounceProbe : PredictedIdentity<BounceProbe.ProbeState>
     /// </summary>
     private const float MinCountedImpactSpeed = 1f;
 
-    private void OnBounce(GameObject other, PhysicsCollision collision)
+    private void OnBounce(GameObject other, PredictedComponentID otherId, PhysicsCollision collision)
     {
         if (!predictionManager.isVerifiedView)
             return;

--- a/Assets/PredictionTests/Scripts/Scenarios/SmokeZoneTracker.cs
+++ b/Assets/PredictionTests/Scripts/Scenarios/SmokeZoneTracker.cs
@@ -62,24 +62,18 @@ public class SmokeZoneTracker : PredictedIdentity<SmokeZoneTracker.ZoneState>
         instances.Remove(this);
     }
 
-    private void OnPredictedTriggerEnter(GameObject other)
+    private void OnPredictedTriggerEnter(GameObject other, PredictedComponentID otherId)
     {
-        if (!PredictionManager.TryGetClosestPredictedID(other, out var pid))
-            return;
-
         enterFires++;
-        var id = pid.objectId;
+        var id = otherId.objectId;
         if (!currentState.insideIds.Contains(id))
             currentState.insideIds.Add(id);
     }
 
-    private void OnPredictedTriggerExit(GameObject other)
+    private void OnPredictedTriggerExit(GameObject other, PredictedComponentID otherId)
     {
-        if (!PredictionManager.TryGetClosestPredictedID(other, out var pid))
-            return;
-
         exitFires++;
-        var id = pid.objectId;
+        var id = otherId.objectId;
         if (currentState.insideIds.Contains(id))
             currentState.insideIds.Remove(id);
     }

--- a/Assets/PurrDiction/Examples/ProjectileShooter.cs
+++ b/Assets/PurrDiction/Examples/ProjectileShooter.cs
@@ -35,7 +35,7 @@ namespace PurrDiction.Examples
 
             projectile.AddImpulse(transform.forward * _initialForce);
             if(projectile.isTrigger)
-                projectile.onTriggerEnter += (other) => OnProjectileTriggerEnter(projectile, other);
+                projectile.onTriggerEnter += (other, _) => OnProjectileTriggerEnter(projectile, other);
         }
 
         private void OnProjectileTriggerEnter(PredictedProjectile3D projectile, GameObject other)

--- a/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted2DPhysics.cs
+++ b/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted2DPhysics.cs
@@ -121,20 +121,21 @@ namespace PurrNet.Prediction
             if (ev.me.TryGetIdentity<PredictedRigidbody2D>(predictionManager, out var me))
             {
                 var otherGo = ev.other.GetGameObject(predictionManager);
-                if (!otherGo && ev.other.objectId.instanceId.value != 0)
+                if (!otherGo && ev.type != PhysicsEventType.Exit &&
+                    ev.other.objectId.instanceId.value != 0)
                     return;
                 if (ev.isTrigger)
                 {
                     switch (ev.type)
                     {
                         case PhysicsEventType.Enter:
-                            me.RaiseTriggerEnter(otherGo);
+                            me.RaiseTriggerEnter(otherGo, ev.other);
                             break;
                         case PhysicsEventType.Exit:
-                            me.RaiseTriggerExit(otherGo);
+                            me.RaiseTriggerExit(otherGo, ev.other);
                             break;
                         case PhysicsEventType.Stay:
-                            me.RaiseTriggerStay(otherGo);
+                            me.RaiseTriggerStay(otherGo, ev.other);
                             break;
                         default: throw new ArgumentOutOfRangeException();
                     }
@@ -144,13 +145,13 @@ namespace PurrNet.Prediction
                     switch (ev.type)
                     {
                         case PhysicsEventType.Enter:
-                            me.RaiseCollisionEnter(otherGo, ev.contacts);
+                            me.RaiseCollisionEnter(otherGo, ev.other, ev.contacts);
                             break;
                         case PhysicsEventType.Exit:
-                            me.RaiseCollisionExit(otherGo, ev.contacts);
+                            me.RaiseCollisionExit(otherGo, ev.other, ev.contacts);
                             break;
                         case PhysicsEventType.Stay:
-                            me.RaiseCollisionStay(otherGo, ev.contacts);
+                            me.RaiseCollisionStay(otherGo, ev.other, ev.contacts);
                             break;
                         default: throw new ArgumentOutOfRangeException();
                     }

--- a/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted3DPhysics.cs
+++ b/Assets/PurrDiction/Runtime/PhysicsEvents/Predicted3DPhysics.cs
@@ -59,20 +59,21 @@ namespace PurrNet.Prediction
             if (ev.me.TryGetIdentity<IPredictedPhysicsCallbacks>(predictionManager, out var me))
             {
                 var otherGo = ev.other.GetGameObject(predictionManager);
-                if (!otherGo && ev.other.objectId.instanceId.value != 0)
+                if (!otherGo && ev.type != PhysicsEventType.Exit &&
+                    ev.other.objectId.instanceId.value != 0)
                     return;
                 if (ev.isTrigger)
                 {
                     switch (ev.type)
                     {
                         case PhysicsEventType.Enter:
-                            me.RaiseTriggerEnter(otherGo);
+                            me.RaiseTriggerEnter(otherGo, ev.other);
                             break;
                         case PhysicsEventType.Exit:
-                            me.RaiseTriggerExit(otherGo);
+                            me.RaiseTriggerExit(otherGo, ev.other);
                             break;
                         case PhysicsEventType.Stay:
-                            me.RaiseTriggerStay(otherGo);
+                            me.RaiseTriggerStay(otherGo, ev.other);
                             break;
                         default: throw new ArgumentOutOfRangeException();
                     }
@@ -82,13 +83,13 @@ namespace PurrNet.Prediction
                     switch (ev.type)
                     {
                         case PhysicsEventType.Enter:
-                            me.RaiseCollisionEnter(otherGo, ev.collision);
+                            me.RaiseCollisionEnter(otherGo, ev.other, ev.collision);
                             break;
                         case PhysicsEventType.Exit:
-                            me.RaiseCollisionExit(otherGo, ev.collision);
+                            me.RaiseCollisionExit(otherGo, ev.other, ev.collision);
                             break;
                         case PhysicsEventType.Stay:
-                            me.RaiseCollisionStay(otherGo, ev.collision);
+                            me.RaiseCollisionStay(otherGo, ev.other, ev.collision);
                             break;
                         default: throw new ArgumentOutOfRangeException();
                     }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/IPredictedPhysicsCallbacks.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/IPredictedPhysicsCallbacks.cs
@@ -4,16 +4,19 @@ namespace PurrNet.Prediction
 {
     public interface IPredictedPhysicsCallbacks
     {
-        public void RaiseTriggerEnter(GameObject other);
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId);
 
-        public void RaiseTriggerExit(GameObject other);
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId);
 
-        public void RaiseTriggerStay(GameObject other);
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId);
 
-        public void RaiseCollisionEnter(GameObject other, PhysicsCollision evContacts);
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts);
 
-        public void RaiseCollisionExit(GameObject other, PhysicsCollision evContacts);
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts);
 
-        public void RaiseCollisionStay(GameObject other, PhysicsCollision evContacts);
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts);
     }
 }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedPhysicsCallbacks.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedPhysicsCallbacks.cs
@@ -17,17 +17,26 @@ namespace PurrNet.Prediction
 
         public event OnControllerColliderHitDelegate onControllerColliderHit;
 
-        public void RaiseTriggerEnter(GameObject other) => onTriggerEnter?.Invoke(other);
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId)
+            => onTriggerEnter?.Invoke(other, otherId);
 
-        public void RaiseTriggerExit(GameObject other) => onTriggerExit?.Invoke(other);
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId)
+            => onTriggerExit?.Invoke(other, otherId);
 
-        public void RaiseTriggerStay(GameObject other) => onTriggerStay?.Invoke(other);
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId)
+            => onTriggerStay?.Invoke(other, otherId);
 
-        public void RaiseCollisionEnter(GameObject other, PhysicsCollision evContacts) => onCollisionEnter?.Invoke(other, evContacts);
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionEnter?.Invoke(other, otherId, evContacts);
 
-        public void RaiseCollisionExit(GameObject other, PhysicsCollision evContacts) => onCollisionExit?.Invoke(other, evContacts);
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionExit?.Invoke(other, otherId, evContacts);
 
-        public void RaiseCollisionStay(GameObject other, PhysicsCollision evContacts) => onCollisionStay?.Invoke(other, evContacts);
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionStay?.Invoke(other, otherId, evContacts);
 
         public void RaiseControllerColliderHit(GameObject other, PhysicsControllerHit hit)
             => onControllerColliderHit?.Invoke(other, hit);

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedProjectile3D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedProjectile3D.cs
@@ -366,13 +366,26 @@ namespace PurrNet.Prediction
             currentState.velocity += impulse;
         }
 
-        public void RaiseTriggerEnter(GameObject other) => onTriggerEnter?.Invoke(other);
-        public void RaiseTriggerExit(GameObject other) => onTriggerExit?.Invoke(other);
-        public void RaiseTriggerStay(GameObject other) => onTriggerStay?.Invoke(other);
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId)
+            => onTriggerEnter?.Invoke(other, otherId);
 
-        public void RaiseCollisionEnter(GameObject other, PhysicsCollision evContacts) => onCollisionEnter?.Invoke(other, evContacts);
-        public void RaiseCollisionExit(GameObject other, PhysicsCollision evContacts) => onCollisionExit?.Invoke(other, evContacts);
-        public void RaiseCollisionStay(GameObject other, PhysicsCollision evContacts) => onCollisionStay?.Invoke(other, evContacts);
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId)
+            => onTriggerExit?.Invoke(other, otherId);
+
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId)
+            => onTriggerStay?.Invoke(other, otherId);
+
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionEnter?.Invoke(other, otherId, evContacts);
+
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionExit?.Invoke(other, otherId, evContacts);
+
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
+            => onCollisionStay?.Invoke(other, otherId, evContacts);
 
         protected override ProjectileState3D Interpolate(ProjectileState3D from, ProjectileState3D to, float t)
         {

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody.cs
@@ -26,8 +26,9 @@ namespace PurrNet.Prediction
         Low = 2
     }
 
-    public delegate void OnCollisionDelegate(GameObject other, PhysicsCollision physicsEvent);
-    public delegate void OnTriggerDelegate(GameObject other);
+    public delegate void OnCollisionDelegate(GameObject other, PredictedComponentID otherId,
+        PhysicsCollision physicsEvent);
+    public delegate void OnTriggerDelegate(GameObject other, PredictedComponentID otherId);
     public delegate void OnControllerColliderHitDelegate(GameObject other, PhysicsControllerHit physicsEvent);
 
 #if UNITY_PHYSICS_3D
@@ -746,62 +747,68 @@ namespace PurrNet.Prediction
         }
 
 
-        public void RaiseTriggerEnter(GameObject other)
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId)
         {
-            onTriggerEnter?.Invoke(other);
+            onTriggerEnter?.Invoke(other, otherId);
         }
 
-        public void RaiseTriggerExit(GameObject other)
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId)
         {
-            onTriggerExit?.Invoke(other);
+            onTriggerExit?.Invoke(other, otherId);
         }
 
-        public void RaiseTriggerStay(GameObject other)
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId)
         {
-            onTriggerStay?.Invoke(other);
+            onTriggerStay?.Invoke(other, otherId);
         }
 
-        public void RaiseCollisionEnter(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
-            onCollisionEnter?.Invoke(other, evContacts);
+            onCollisionEnter?.Invoke(other, otherId, evContacts);
         }
 
-        public void RaiseCollisionExit(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
-            onCollisionExit?.Invoke(other, evContacts);
+            onCollisionExit?.Invoke(other, otherId, evContacts);
         }
 
-        public void RaiseCollisionStay(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
-            onCollisionStay?.Invoke(other, evContacts);
+            onCollisionStay?.Invoke(other, otherId, evContacts);
         }
 #else
-        public void RaiseTriggerEnter(GameObject other)
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId)
         {
             throw new NotImplementedException();
         }
 
-        public void RaiseTriggerExit(GameObject other)
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId)
         {
             throw new NotImplementedException();
         }
 
-        public void RaiseTriggerStay(GameObject other)
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId)
         {
             throw new NotImplementedException();
         }
 
-        public void RaiseCollisionEnter(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
             throw new NotImplementedException();
         }
 
-        public void RaiseCollisionExit(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
             throw new NotImplementedException();
         }
 
-        public void RaiseCollisionStay(GameObject other, PhysicsCollision evContacts)
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision evContacts)
         {
             throw new NotImplementedException();
         }

--- a/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
+++ b/Assets/PurrDiction/Runtime/UnityPhysics/PredictedRigidbody2D.cs
@@ -15,8 +15,9 @@ namespace PurrNet.Prediction
         [SerializeField, Min(0f)] private float _softVelocityCorrectionRate = 8f;
 
 #if UNITY_PHYSICS_2D
-        public delegate void OnCollisionDelegate(GameObject other, DisposableList<Physics2DContactPoint> evContacts);
-        public delegate void OnTriggerDelegate(GameObject other);
+        public delegate void OnCollisionDelegate(GameObject other, PredictedComponentID otherId,
+            DisposableList<Physics2DContactPoint> evContacts);
+        public delegate void OnTriggerDelegate(GameObject other, PredictedComponentID otherId);
 
         [SerializeField] private Rigidbody2D _rigidbody;
         [SerializeField] private PhysicsEventMask _eventMask = (PhysicsEventMask)0x3F;
@@ -503,25 +504,31 @@ namespace PurrNet.Prediction
             predictionManager.physics2d.RegisterEvent(PhysicsEventType.Stay, this, other);
         }
 
-        public void RaiseTriggerEnter(GameObject other) => onTriggerEnter?.Invoke(other);
+        public void RaiseTriggerEnter(GameObject other, PredictedComponentID otherId)
+            => onTriggerEnter?.Invoke(other, otherId);
 
-        public void RaiseTriggerExit(GameObject other) => onTriggerExit?.Invoke(other);
+        public void RaiseTriggerExit(GameObject other, PredictedComponentID otherId)
+            => onTriggerExit?.Invoke(other, otherId);
 
-        public void RaiseTriggerStay(GameObject other) => onTriggerStay?.Invoke(other);
+        public void RaiseTriggerStay(GameObject other, PredictedComponentID otherId)
+            => onTriggerStay?.Invoke(other, otherId);
 
-        public void RaiseCollisionEnter(GameObject other, DisposableList<Physics2DContactPoint> evContacts)
+        public void RaiseCollisionEnter(GameObject other, PredictedComponentID otherId,
+            DisposableList<Physics2DContactPoint> evContacts)
         {
-            onCollisionEnter?.Invoke(other, evContacts);
+            onCollisionEnter?.Invoke(other, otherId, evContacts);
         }
 
-        public void RaiseCollisionExit(GameObject other, DisposableList<Physics2DContactPoint> evContacts)
+        public void RaiseCollisionExit(GameObject other, PredictedComponentID otherId,
+            DisposableList<Physics2DContactPoint> evContacts)
         {
-            onCollisionExit?.Invoke(other, evContacts);
+            onCollisionExit?.Invoke(other, otherId, evContacts);
         }
 
-        public void RaiseCollisionStay(GameObject other, DisposableList<Physics2DContactPoint> evContacts)
+        public void RaiseCollisionStay(GameObject other, PredictedComponentID otherId,
+            DisposableList<Physics2DContactPoint> evContacts)
         {
-            onCollisionStay?.Invoke(other, evContacts);
+            onCollisionStay?.Invoke(other, otherId, evContacts);
         }
 
         public Vector2 position

--- a/Assets/PurrDictionTests/EditorTests/IdentityRegistrationTests.cs
+++ b/Assets/PurrDictionTests/EditorTests/IdentityRegistrationTests.cs
@@ -73,7 +73,8 @@ namespace PurrNet.Prediction.Tests.Editor
             }
             finally
             {
-                Object.DestroyImmediate(identityObject);
+                if (identityObject)
+                    Object.DestroyImmediate(identityObject);
                 Object.DestroyImmediate(managerObject);
             }
         }
@@ -116,5 +117,6 @@ namespace PurrNet.Prediction.Tests.Editor
             Assert.That(field, Is.Not.Null, $"missing field {name}");
             field.SetValue(manager, value);
         }
+
     }
 }

--- a/Assets/PurrDictionTests/OhYeahBaby.cs
+++ b/Assets/PurrDictionTests/OhYeahBaby.cs
@@ -19,9 +19,11 @@ namespace PurrNet.Prediction.Tests
             _rb.onTriggerExit -= OnPTriggerExit;
         }
 
-        private void OnPTriggerEnter(GameObject other)
+        private void OnPTriggerEnter(GameObject other, PredictedComponentID otherId)
         {
             if (!isServer)
+                return;
+            if (!other)
                 return;
             if (other.TryGetComponent<SimpleCC>(out var controller))
             {
@@ -34,9 +36,11 @@ namespace PurrNet.Prediction.Tests
             }
         }
 
-        private void OnPTriggerExit(GameObject other)
+        private void OnPTriggerExit(GameObject other, PredictedComponentID otherId)
         {
             if (!isServer)
+                return;
+            if (!other)
                 return;
             if (other.TryGetComponent<SimpleCC>(out var controller))
             {

--- a/Assets/PurrDictionTests/SimpleRotatingPlatform.cs
+++ b/Assets/PurrDictionTests/SimpleRotatingPlatform.cs
@@ -55,12 +55,13 @@ namespace PurrNet.Prediction.Tests
             predictionManager.hierarchy.Delete(gameObject);*/
         }
 
-        private void OnUnityTriggerEnter(GameObject other)
+        private void OnUnityTriggerEnter(GameObject other, PredictedComponentID otherId)
         {
             PurrLogger.Log($"Triggered with {other} on {gameObject.name}");
         }
 
-        private void OnUnityCollisionEnter(GameObject other, PhysicsCollision collision)
+        private void OnUnityCollisionEnter(GameObject other, PredictedComponentID otherId,
+            PhysicsCollision collision)
         {
             PurrLogger.Log($"Collided with {other} on {gameObject.name}");
             currentState.collisionCount += 1;


### PR DESCRIPTION
An alternative to the problem raised in #56. Related PRs: #56, #57, #72.

This is perhaps the cleanest solution to the problem of collision exits due to deleted identities, albeit the most breaking change.

Rather than cacheing recently-deleted identities to be surfaced in `PredictedRigidbody2/3D.onCollisionExit(GameObject other, ...)`, this implementation includes a PredictedComponentID in all physics events making the equivalent `PredictedRigidbody2/3D.onCollisionExit(GameObject other, PredictedComponentID otherId, ...)`. The checks in Assets/PurrDiction/Runtime/PhysicsEvents/Predicted2DPhysics.cs:124 and Assets/PurrDiction/Runtime/PhysicsEvents/Predicted3DPhysics.cs:62 now fire exit events despite the other GameObject being falsy.

In short, the issue with collision/trigger exit events is that we're not guaranteed to have a valid GameObject to refer to. Therefore, with the current physics event signatures, we can either hide the exit event (current behaviour) or present the event with a `null` GameObject. Neither of these options are great. This proposal includes the PredictedComponentID in all physics events which is guaranteed to exist despite the GameObject being `null`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/73"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791239941&installation_model_id=20441&pr_number=73&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F73&signature=7164f78b96538ff8045dc7d99689703b952fc5197a18b5f393181a69f5497ded"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->