### PR TITLE
Add LateUpdateView to StatelessPredictedIdentity

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/StatelessPredictedIdentity.cs
+++ b/Assets/PurrDiction/Runtime/Core/StatelessPredictedIdentity.cs
@@ -42,10 +42,22 @@ namespace PurrNet.Prediction
 #pragma warning restore CS0618 // Type or member is obsolete
         }
 
+        internal override void LateUpdateView(float deltaTime)
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            LateUpdateView(default, default);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
         [Obsolete("Use UpdateView() instead."), UsedImplicitly, MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected virtual void UpdateView(StatelessHeSaid stateless, StatelessHeSaid? verified) => UpdateView();
 
+        [Obsolete("Use LateUpdateView() instead."), UsedImplicitly, MethodImpl(MethodImplOptions.AggressiveInlining)]
+        protected virtual void LateUpdateView(StatelessHeSaid stateless, StatelessHeSaid? verified) => LateUpdateView();
+
         protected virtual void UpdateView() { }
+
+        protected virtual void LateUpdateView() { }
 
         protected virtual void LateSimulate(float delta) {}
 


### PR DESCRIPTION
`StatelessPredictedIdentity` is missing an override for `LateUpdateView`. This PR fixes that. It's implemented the same way `UpdateView` is implemented by calling the obsolete method with the stateless state that in turn calls the actual method.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/74"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791648164&installation_model_id=20441&pr_number=74&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F74&signature=c4626c9a1e09c6ed0a51682cc1cde4c44fc1353e6df664589eba51f1ea509ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->