### PR TITLE
Obsolete fixes

### DIFF
--- a/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedIdentity.cs
@@ -55,6 +55,7 @@ namespace PurrNet.Prediction
         /// The unique identifier for this object.
         /// Can be used to identify the object across the network.
         /// </summary>
+        [NonSerialized]
         public PredictedComponentID id;
 
         /// <summary>

--- a/Assets/PurrDiction/Runtime/Core/PredictedModuleTypeRegistration.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedModuleTypeRegistration.cs
@@ -10,8 +10,14 @@ namespace PurrNet.Prediction
         private static void RegisterAllModuleTypes()
         {
             var moduleBase = typeof(PredictedModule);
+#if !UNITY_6000_4_OR_NEWER
             var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            for (int a = 0; a < assemblies.Length; a++)
+            var length = assemblies.Length;
+#else
+            var assemblies = UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
+            var length = assemblies.Count;
+#endif
+            for (int a = 0; a < length; a++)
             {
                 Type[] types;
                 try { types = assemblies[a].GetTypes(); }

--- a/Assets/PurrDiction/Runtime/Core/PredictedModuleTypeRegistration.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictedModuleTypeRegistration.cs
@@ -10,12 +10,12 @@ namespace PurrNet.Prediction
         private static void RegisterAllModuleTypes()
         {
             var moduleBase = typeof(PredictedModule);
-#if !UNITY_6000_4_OR_NEWER
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
-            var length = assemblies.Length;
-#else
+#if UNITY_6000_4_OR_NEWER
             var assemblies = UnityEngine.Assemblies.CurrentAssemblies.GetLoadedAssemblies();
             var length = assemblies.Count;
+#else
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var length = assemblies.Length;
 #endif
             for (int a = 0; a < length; a++)
             {

--- a/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
+++ b/Assets/PurrDiction/Runtime/Core/PredictionManager.cs
@@ -295,7 +295,13 @@ namespace PurrNet.Prediction
             for (var i = 0; i < _queue.Count; i++)
                 known.Add(_queue[i]);
 
-            var all = UnityEngine.Object.FindObjectsByType<PredictedIdentity>(FindObjectsSortMode.None);
+            // SortMode was obsoleted in Unity 6.4. Skip the argument in future versions.
+            var all = 
+#if UNITY_6000_4_OR_NEWER
+                UnityEngine.Object.FindObjectsByType<PredictedIdentity>();
+#else
+                UnityEngine.Object.FindObjectsByType<PredictedIdentity>(FindObjectsSortMode.None);
+#endif
             for (var i = 0; i < all.Length; i++)
             {
                 var identity = all[i];


### PR DESCRIPTION
Fixes some obsolete warnings in newer Unity versions and generally future-proofs the package while maintaining backwards compatibility. 

- Replaces `AppDomian.CurrentDomain.GetAssemblies()` with Unity's new way of getting loaded assemblies in Unity 6.4+
- Removes `FindObjectsSortMode` usage in Unity 6.4 as it's obsolete
- Mark `PredictedIdentity.id` as NonSerialized to stop Unity from complaining about trying to serialize it

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/PurrNet/codesmith/PurrDiction/pr/76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791734893&installation_model_id=20441&pr_number=76&repository=PurrNet%2FPurrDiction&return_to=https%3A%2F%2Fgithub.com%2FPurrNet%2FPurrDiction%2Fpull%2F76&signature=65c8f8f94c157f73beb817d031b077bd9083f5d02209a3f57384a02cacbdaeb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->